### PR TITLE
theater: implement a clamped cmds processing loop

### DIFF
--- a/src/dct/settings.lua
+++ b/src/dct/settings.lua
@@ -85,6 +85,8 @@ local function settings(missioncfg)
 			},
 		},
 		["schedfreq"] = 2, -- hertz
+		["tgtfps"] = 75,
+		["percentTimeAllowed"] = .3,
 	}
 
 	if attr ~= nil then

--- a/tests/test-settings.lua
+++ b/tests/test-settings.lua
@@ -31,6 +31,8 @@ local function main()
 			["FA-18C_hornet"] = dctutils.posfmt.DDM,
 		},
 		["schedfreq"] = 2,
+		["percentTimeAllowed"] = .3,
+		["tgtfps"] = 75,
 	}
 
 	for k, v in pairs(cfgvalidation) do


### PR DESCRIPTION
Like other game loops they are usually clamped to a specific FPS to
allow the loop to process as many events as possible without going far
below the target framerate.

Lua's os.clock() API provides millisecond timer resolution which should
be accurate enough for our purposes.