### PR TITLE
settings: allow some airframes to fly other missions

### DIFF
--- a/src/dct/settings.lua
+++ b/src/dct/settings.lua
@@ -54,12 +54,14 @@ local function settings(missioncfg)
 			[coalition.side.RED]  = {},
 			[coalition.side.BLUE] = {
 				["A-10C"] = {
-					["CAS"] = enum.missionType.CAS,
-					["BAI"] = enum.missionType.BAI,
+					["CAS"]    = enum.missionType.CAS,
+					["BAI"]    = enum.missionType.BAI,
+					["STRIKE"] = enum.missionType.STRIKE,
 				},
 				["A-10A"] = {
-					["CAS"] = enum.missionType.CAS,
-					["BAI"] = enum.missionType.BAI,
+					["CAS"]    = enum.missionType.CAS,
+					["BAI"]    = enum.missionType.BAI,
+					["STRIKE"] = enum.missionType.STRIKE,
 				},
 				["F-15C"] = {
 					["CAP"] = enum.missionType.CAP,
@@ -67,16 +69,21 @@ local function settings(missioncfg)
 				["F-5E-3"] = {
 					["STRIKE"] = enum.missionType.STRIKE,
 					["BAI"]    = enum.missionType.BAI,
+					["CAS"]    = enum.missionType.CAS,
+					["OCA"]    = enum.missionType.OCA,
 				},
 				["M-2000C"] = {
 					["STRIKE"] = enum.missionType.STRIKE,
 					["BAI"]    = enum.missionType.BAI,
 					["OCA"]    = enum.missionType.OCA,
+					["CAP"]    = enum.missionType.CAP,
 				},
 				["AV8BNA"] = {
 					["STRIKE"] = enum.missionType.STRIKE,
 					["BAI"]    = enum.missionType.BAI,
 					["OCA"]    = enum.missionType.OCA,
+					["SEAD"]   = enum.missionType.SEAD,
+					["CAS"]    = enum.missionType.CAS,
 				},
 				["AJS37"] = {
 					["STRIKE"] = enum.missionType.STRIKE,

--- a/tests/test-theater.lua
+++ b/tests/test-theater.lua
@@ -14,7 +14,7 @@ local function main()
 
 	local restriction =
 		theater:getATORestrictions(coalition.side.BLUE, "A-10C")
-	local validtbl = { ["BAI"] = 5, ["CAS"] = 1, }
+	local validtbl = { ["BAI"] = 5, ["CAS"] = 1, ["STRIKE"] = 3,}
 	for k, v in pairs(restriction) do
 		assert(validtbl[k] == v, "ATO Restriction error")
 	end


### PR DESCRIPTION
Allow A10s to fly strike missions and M2000Cs to fly CAP missions.

Closes: #42