### PR TITLE
theater: write then rename state file

### DIFF
--- a/src/dct/Theater.lua
+++ b/src/dct/Theater.lua
@@ -168,12 +168,13 @@ end
 function Theater:export(_)
 	local statefile
 	local msg
+	local ok
+	local newfile = settings.statepath..".new"
 
-	statefile, msg = io.open(settings.statepath, "w+")
-
+	statefile, msg = io.open(newfile, "w")
 	if statefile == nil then
-		Logger:error("export(); unable to open '"..
-			settings.statepath.."'; msg: "..tostring(msg))
+		Logger:error("export(); unable to open '"..newfile..
+			"'; msg: "..tostring(msg))
 		return self.savestatefreq
 	end
 
@@ -186,9 +187,22 @@ function Theater:export(_)
 		["startdate"] = self.startdate
 	}
 
-	statefile:write(json:encode_pretty(exporttbl))
+	ok, msg = statefile:write(json:encode_pretty(exporttbl))
+	if ok == nil then
+		Logger:error("export(); '"..newfile.."'; msg: "..tostring(msg))
+		return self.savestatefreq
+	end
 	statefile:flush()
-	statefile:close()
+	ok, msg = statefile:close()
+	if ok == nil then
+		Logger:error("export(); '"..newfile.."'; msg: "..tostring(msg))
+		return self.savestatefreq
+	end
+	ok, msg = os.rename(newfile, settings.statepath)
+	if ok == nil then
+		Logger:error("export(); unable to rename; msg: "..tostring(msg))
+		return self.savestatefreq
+	end
 	return self.savestatefreq
 end
 


### PR DESCRIPTION
To avoid losing the old state file before the new state file is ready
move to a write new rename model so that we are all but guaranteed we
have a new state file before attempting to delete the old one. This is
done by using os.rename which on most filesystems is an atomic operation
and usually cannot fail barring hardware failure.