### PR TITLE
Created new mission type Armed Reconnaissance.

### DIFF
--- a/src/dct/enum.lua
+++ b/src/dct/enum.lua
@@ -60,6 +60,7 @@ local assetTypePriority = {
 	[assetType.FACILITY]    = 100,
 	[assetType.BUNKER]      = 100,
 	[assetType.CHECKPOINT]  = 100,
+	[assetType.SPECIALFORCES] = 100,
 	[assetType.FACTORY]     = 100,
 	[assetType.KEEPOUT]     = 10000,
 }
@@ -71,6 +72,7 @@ local missionType = {
 	["SEAD"]     = 4,
 	["BAI"]      = 5,
 	["OCA"]      = 6,
+	["ARMEDRECON"] = 7,
 }
 
 local assetClass = {
@@ -96,11 +98,12 @@ local assetClass = {
 	-- agents never get seralized to the state file
 	["AGENTS"] = {
 		[assetType.PLAYERGROUP] = true,
-	}
-	--[[
+	},
 	-- Means ground tactical units
 	["TACTICAL"] = {
+		[assetType.SPECIALFORCES] = true,
 	},
+	--[[
 	["AIRBORNE"] = {
 	},
 	--]]
@@ -136,7 +139,7 @@ local missionTypeMap = {
 		[assetType.AIRSPACE]   = true,
 	},
 	[missionType.ARMEDRECON] = {
-		[assetType.TBD] =      = true,
+		[assetType.SPECIALFORCES] = true,
 	},
 }
 

--- a/src/dct/enum.lua
+++ b/src/dct/enum.lua
@@ -135,6 +135,9 @@ local missionTypeMap = {
 	[missionType.CAP] = {
 		[assetType.AIRSPACE]   = true,
 	},
+	[missionType.ARMEDRECON] = {
+		[assetType.TBD] =      = true,
+	},
 }
 
 local missionAbortType = {

--- a/src/dct/enum.lua
+++ b/src/dct/enum.lua
@@ -35,6 +35,7 @@ local assetType = {
 	["SHORAD"]      = 19,
 	["AIRBASE"]     = 20,
 	["PLAYERGROUP"] = 21,
+	["SPECIALFORCES"] = 22,
 }
 
 --[[
@@ -91,6 +92,7 @@ local assetClass = {
 		[assetType.FACTORY]     = true,
 		[assetType.SHORAD]      = true,
 		[assetType.AIRBASE]     = true,
+		[assetType.SPECIALFORCES] = true,
 	},
 	["BASES"] = {
 		[assetType.AIRBASE]     = true,
@@ -99,11 +101,11 @@ local assetClass = {
 	["AGENTS"] = {
 		[assetType.PLAYERGROUP] = true,
 	},
+	--[[
 	-- Means ground tactical units
 	["TACTICAL"] = {
 		[assetType.SPECIALFORCES] = true,
 	},
-	--[[
 	["AIRBORNE"] = {
 	},
 	--]]

--- a/src/dct/enum.lua
+++ b/src/dct/enum.lua
@@ -36,6 +36,7 @@ local assetType = {
 	["AIRBASE"]     = 20,
 	["PLAYERGROUP"] = 21,
 	["SPECIALFORCES"] = 22,
+	["FOB"]           = 23,
 }
 
 --[[
@@ -62,6 +63,7 @@ local assetTypePriority = {
 	[assetType.BUNKER]      = 100,
 	[assetType.CHECKPOINT]  = 100,
 	[assetType.SPECIALFORCES] = 100,
+	[assetType.FOB]         = 100,
 	[assetType.FACTORY]     = 100,
 	[assetType.KEEPOUT]     = 10000,
 }
@@ -93,6 +95,7 @@ local assetClass = {
 		[assetType.SHORAD]      = true,
 		[assetType.AIRBASE]     = true,
 		[assetType.SPECIALFORCES] = true,
+		[assetType.FOB]           = true,
 	},
 	["BASES"] = {
 		[assetType.AIRBASE]     = true,
@@ -142,6 +145,7 @@ local missionTypeMap = {
 	},
 	[missionType.ARMEDRECON] = {
 		[assetType.SPECIALFORCES] = true,
+		[assetType.FOB]           = true,
 	},
 }
 

--- a/src/dct/settings.lua
+++ b/src/dct/settings.lua
@@ -67,10 +67,10 @@ local function settings(missioncfg)
 					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["A-10C_2"] = {
-                                        ["CAS"]    = enum.missionType.CAS,
-                                        ["BAI"]    = enum.missionType.BAI,
-                                        ["STRIKE"] = enum.missionType.STRIKE,
-                                        ["ARMEDRECON"] = enum.missionType.ARMEDRECON,
+					["CAS"]    = enum.missionType.CAS,
+					["BAI"]    = enum.missionType.BAI,
+					["STRIKE"] = enum.missionType.STRIKE,
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
                                 },
 				["A-10A"] = {
 					["CAS"]    = enum.missionType.CAS,
@@ -86,6 +86,7 @@ local function settings(missioncfg)
 					["BAI"]    = enum.missionType.BAI,
 					["CAS"]    = enum.missionType.CAS,
 					["OCA"]    = enum.missionType.OCA,
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["M-2000C"] = {
 					["STRIKE"] = enum.missionType.STRIKE,
@@ -99,34 +100,42 @@ local function settings(missioncfg)
 					["OCA"]    = enum.missionType.OCA,
 					["SEAD"]   = enum.missionType.SEAD,
 					["CAS"]    = enum.missionType.CAS,
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["AJS37"] = {
 					["STRIKE"] = enum.missionType.STRIKE,
 					["OCA"]    = enum.missionType.OCA,
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["Ka-50"] = {
+					["STRIKE"] = enum.missionType.STRIKE,
 					["BAI"] = enum.missionType.BAI,
 					["CAS"] = enum.missionType.CAS,
 					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["UH-1H"] = {
+					["CAS"]        = enum.missionType.CAS,
 					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["Mi-8MT"] = {
+					["CAS"]        = enum.missionType.CAS,
 					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["SA342M"] = {
+					["CAS"]        = enum.missionType.CAS,
 					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["SA342L"] = {
+					["CAS"]        = enum.missionType.CAS,
 					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["Su-25T"] = {
 					["STRIKE"] = enum.missionType.STRIKE,
-                                        ["BAI"]    = enum.missionType.BAI,
-                                        ["OCA"]    = enum.missionType.OCA,
-                                        ["SEAD"]   = enum.missionType.SEAD,
-                                        ["CAS"]    = enum.missionType.CAS,
+					["BAI"]    = enum.missionType.BAI,
+					["OCA"]    = enum.missionType.OCA,
+					["SEAD"]   = enum.missionType.SEAD,
+					["CAS"]    = enum.missionType.CAS,
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["FA-18C_Hornet"] = {
 					["OCA"]    = enum.missionType.OCA,
@@ -138,11 +147,11 @@ local function settings(missioncfg)
 				},
 				["F-16C_50"] = {
 					["OCA"]    = enum.missionType.OCA,
-                                        ["BAI"]    = enum.missionType.BAI,
-                                        ["CAP"]    = enum.missionType.CAP,
-                                        ["STRIKE"] = enum.missionType.STRIKE,
-                                        ["SEAD"]   = enum.missionType.SEAD,
-                                        ["CAS"]    = enum.missionType.CAS,
+					["BAI"]    = enum.missionType.BAI,
+					["CAP"]    = enum.missionType.CAP,
+					["STRIKE"] = enum.missionType.STRIKE,
+					["SEAD"]   = enum.missionType.SEAD,
+					["CAS"]    = enum.missionType.CAS,
 				},
 
 			},

--- a/src/dct/settings.lua
+++ b/src/dct/settings.lua
@@ -56,6 +56,7 @@ local function settings(missioncfg)
 					["CAS"]    = enum.missionType.CAS,
 					["BAI"]    = enum.missionType.BAI,
 					["STRIKE"] = enum.missionType.STRIKE,
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["A-10A"] = {
 					["CAS"]    = enum.missionType.CAS,
@@ -88,6 +89,18 @@ local function settings(missioncfg)
 					["STRIKE"] = enum.missionType.STRIKE,
 					["OCA"]    = enum.missionType.OCA,
 				},
+				["KA-50"] = {
+					["BAI"] = enum.missionType.BAI,
+					["CAS"] = enum.missionType.CAS,
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
+				},
+				["UH-1H"] = {
+					["ARMEDRECON"] = enum.misssionType.ARMEDRECON,
+				},
+				["Mi-8MT"] = {
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
+				},
+
 			},
 		},
 		["schedfreq"] = 2, -- hertz

--- a/src/dct/settings.lua
+++ b/src/dct/settings.lua
@@ -55,6 +55,7 @@ local function settings(missioncfg)
 			["SA342M"]	  = dctutils.posfmt.DDM,
 			["SA342L"]	  = dctutils.posfmt.DDM,
 			["A-10C_2"]	  = dctutils.posfmt.MGRS,
+			["KA-50"]	  = dctutils.posfmt.DDM,
 		},
 		["codenamedb"] = codenamedb,
 		["atorestrictions"] = {

--- a/src/dct/settings.lua
+++ b/src/dct/settings.lua
@@ -45,7 +45,7 @@ local function settings(missioncfg)
 			["M-2000C"]       = dctutils.posfmt.DDM,
 			["A-10C"]         = dctutils.posfmt.MGRS,
 			["AJS37"]         = dctutils.posfmt.DMS,
-			["F-14B"]         = dctutils.posfmt.DDM,
+			["F-14B"]         = dctutils.posfmt.DMS,
 			["FA-18C_hornet"] = dctutils.posfmt.DDM,
 			["F-16C_50"] 	  = dctutils.posfmt.DDM,
 			["UH-1H"] 	  = dctutils.posfmt.DDM,

--- a/src/dct/settings.lua
+++ b/src/dct/settings.lua
@@ -47,11 +47,14 @@ local function settings(missioncfg)
 			["AJS37"]         = dctutils.posfmt.DMS,
 			["F-14B"]         = dctutils.posfmt.DDM,
 			["FA-18C_hornet"] = dctutils.posfmt.DDM,
-			["F-16C"] 	  = dctutils.posfmt.DMS,
+			["F-16C_50"] 	  = dctutils.posfmt.DDM,
 			["UH-1H"] 	  = dctutils.posfmt.DDM,
 			["Mi-8MT"]	  = dctutils.posfmt.DDM,
 			["F-5E-3"]	  = dctutils.posfmt.DDM,
 			["AV8BNA"]	  = dctutils.posfmt.DDM,
+			["SA342M"]	  = dctutils.posfmt.DDM,
+			["SA342L"]	  = dctutils.posfmt.DDM,
+			["A-10C_2"]	  = dctutils.posfmt.MGRS,
 		},
 		["codenamedb"] = codenamedb,
 		["atorestrictions"] = {
@@ -63,10 +66,17 @@ local function settings(missioncfg)
 					["STRIKE"] = enum.missionType.STRIKE,
 					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
+				["A-10C_2"] = {
+                                        ["CAS"]    = enum.missionType.CAS,
+                                        ["BAI"]    = enum.missionType.BAI,
+                                        ["STRIKE"] = enum.missionType.STRIKE,
+                                        ["ARMEDRECON"] = enum.missionType.ARMEDRECON,
+                                },
 				["A-10A"] = {
 					["CAS"]    = enum.missionType.CAS,
 					["BAI"]    = enum.missionType.BAI,
 					["STRIKE"] = enum.missionType.STRIKE,
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["F-15C"] = {
 					["CAP"] = enum.missionType.CAP,
@@ -104,6 +114,35 @@ local function settings(missioncfg)
 				},
 				["Mi-8MT"] = {
 					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
+				},
+				["SA342M"] = {
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
+				},
+				["SA342L"] = {
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
+				},
+				["Su-25T"] = {
+					["STRIKE"] = enum.missionType.STRIKE,
+                                        ["BAI"]    = enum.missionType.BAI,
+                                        ["OCA"]    = enum.missionType.OCA,
+                                        ["SEAD"]   = enum.missionType.SEAD,
+                                        ["CAS"]    = enum.missionType.CAS,
+				},
+				["FA-18C_Hornet"] = {
+					["OCA"]    = enum.missionType.OCA,
+					["BAI"]    = enum.missionType.BAI,
+					["CAP"]    = enum.missionType.CAP,
+					["STRIKE"] = enum.missionType.STRIKE,
+					["SEAD"]   = enum.missionType.SEAD,
+					["CAS"]    = enum.missionType.CAS,
+				},
+				["F-16C_50"] = {
+					["OCA"]    = enum.missionType.OCA,
+                                        ["BAI"]    = enum.missionType.BAI,
+                                        ["CAP"]    = enum.missionType.CAP,
+                                        ["STRIKE"] = enum.missionType.STRIKE,
+                                        ["SEAD"]   = enum.missionType.SEAD,
+                                        ["CAS"]    = enum.missionType.CAS,
 				},
 
 			},

--- a/src/dct/settings.lua
+++ b/src/dct/settings.lua
@@ -47,6 +47,11 @@ local function settings(missioncfg)
 			["AJS37"]         = dctutils.posfmt.DMS,
 			["F-14B"]         = dctutils.posfmt.DDM,
 			["FA-18C_hornet"] = dctutils.posfmt.DDM,
+			["F-16C"] 	  = dctutils.posfmt.DMS,
+			["UH-1H"] 	  = dctutils.posfmt.DDM,
+			["Mi-8MT"]	  = dctutils.posfmt.DDM,
+			["F-5E-3"]	  = dctutils.posfmt.DDM,
+			["AV8BNA"]	  = dctutils.posfmt.DDM,
 		},
 		["codenamedb"] = codenamedb,
 		["atorestrictions"] = {
@@ -89,13 +94,13 @@ local function settings(missioncfg)
 					["STRIKE"] = enum.missionType.STRIKE,
 					["OCA"]    = enum.missionType.OCA,
 				},
-				["KA-50"] = {
+				["Ka-50"] = {
 					["BAI"] = enum.missionType.BAI,
 					["CAS"] = enum.missionType.CAS,
 					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["UH-1H"] = {
-					["ARMEDRECON"] = enum.misssionType.ARMEDRECON,
+					["ARMEDRECON"] = enum.missionType.ARMEDRECON,
 				},
 				["Mi-8MT"] = {
 					["ARMEDRECON"] = enum.missionType.ARMEDRECON,


### PR DESCRIPTION
Added new mission type Armed Reconnaissance and two new asset types, "FOB" and "SPECIALFORCES" which go under the Armed Reconnaissance mission type.  Added this mission type to all of the helicopters, attack aircraft, and light attack aircraft. 

Defined coordinates for all remaining aircraft and set appropriately for their navigation systems, where applicable.

Added A-10C_II support as a consequence of adding Armed Reconnaissance missions to it. It has the same missions as the A-10C and A-10A.

Defined missions for the F-16 and F-18 so that armed reconnaissance can be excluded from their mission sets. We may want to consider implementing an exclusion list at some point, as the settings.lua would thus require less lines of code.