### PR TITLE
Theater cleanup

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -43,5 +43,5 @@ files["tests/test-0001-data.lua"] = {
 	globals = {"staticTemplate", "metadata",}
 }
 files["tests/*"] = {
-	globals = {"dctsettings", "dctcheck", },
+	globals = {"dctcheck", "dct"},
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -9,6 +9,7 @@ read_globals = {
 	"md5",
 
 	-- DCS specific globals
+	"country",
 	"env",
 	"Unit",
 	"Object",

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ build:
 	cp -a $(SRCPATH)/src/dct.lua $(SRCPATH)/src/dct/ $(BUILDPATH)/DCT/lua
 	sed -e "s:%VERSION%:$(VERSION):" $(SRCPATH)/entry.lua.tpl > \
 		$(BUILDPATH)/DCT/entry.lua
+	sed -i -e "s:%VERSION%:$(VERSION):" $(SRCPATH)/src/dct.lua
 	cp -a $(SRCPATH)/mission $(BUILDPATH)/DCT/
 	mkdir -p $(BUILDPATH)/HOOKS
 	cp -a $(SRCPATH)/hooks/* $(BUILDPATH)/HOOKS/

--- a/mission/dct-mission-init.lua
+++ b/mission/dct-mission-init.lua
@@ -9,30 +9,31 @@
 -- then setup and start the framework.
 --]]
 
-if not lfs or not io or not require then
-	local assertmsg = "DCT requires DCS mission scripting environment to be" ..
-		" modified, the file needing to be changed can be found at" ..
-		" $DCS_ROOT\\Scripts\\MissionScripting.lua. Comment out the" ..
-		" removal of lfs and io and the setting of 'require' to nil."
-	assert(false, assertmsg)
-end
-
--- 'dctsettings' can be defined in the mission to override any of the
--- possible dct settings.
-dctsettings = dctsettings or {}
-
--- Check that DCT mod is installed
-local modpath = lfs.writedir() .. "Mods\\tech\\DCT"
-if lfs.attributes(modpath) == nil then
-	local errmsg = "DCT: module not installed, mission not DCT enabled"
-	if dctsettings.nomodlog then
-		env.error(errmsg)
-	else
-		assert(false, errmsg)
+do
+	if not lfs or not io or not require then
+		local assertmsg = "DCT requires DCS mission scripting environment"..
+			" to be modified, the file needing to be changed can be found"..
+			" at $DCS_ROOT\\Scripts\\MissionScripting.lua. Comment out"..
+			" the removal of lfs and io and the setting of 'require' to"..
+			" nil."
+		assert(false, assertmsg)
 	end
-else
-	package.path = package.path .. ";" .. modpath .. "\\lua\\?.lua;"
-	require("dct")
-	dct.init()
-end
 
+	-- 'dctsettings' can be defined in the mission to set nomodlog
+	dctsettings = dctsettings or {}
+
+	-- Check that DCT mod is installed
+	local modpath = lfs.writedir() .. "Mods\\tech\\DCT"
+	if lfs.attributes(modpath) == nil then
+		local errmsg = "DCT: module not installed, mission not DCT enabled"
+		if dctsettings.nomodlog then
+			env.error(errmsg)
+		else
+			assert(false, errmsg)
+		end
+	else
+		package.path = package.path .. ";" .. modpath .. "\\lua\\?.lua;"
+		require("dct")
+		dct.init()
+	end
+end

--- a/src/dct.lua
+++ b/src/dct.lua
@@ -1,7 +1,7 @@
 -- SPDX-License-Identifier: LGPL-3.0
 
 local dct = {
-    _VERSION = "0.6",
+    _VERSION = "%VERSION%",
     _DESCRIPTION = "DCT: DCS Dynamic Campaign Tools",
     _COPYRIGHT = "Copyright (c) 2019-2020 Jonathan Toppins"
 }
@@ -12,4 +12,6 @@ dct.Logger    = require("dct.libs.Logger")
 dct.init      = require("dct.init")
 dct.Theater   = require("dct.Theater")
 
+env.info(dct._DESCRIPTION.."; "..dct._COPYRIGHT.."; version: "..
+    dct._VERSION)
 return dct

--- a/src/dct/Command.lua
+++ b/src/dct/Command.lua
@@ -2,18 +2,27 @@
 -- SPDX-License-Identifier: LGPL-3.0
 --
 -- Provides a basic Command class to call an arbitrary function
--- at a later time via the Command's ececute function.
+-- at a later time via the Command's execute function.
 --]]
 
 local class = require("libs.class")
 local utils = require("libs.utils")
+
+-- lower value is higher priority; total of 127 priority values
+local cmdpriority = {
+	["UI"]     = 10,
+	["NORMAL"] = 64,
+}
 
 local Command = class()
 function Command:__init(func, ...)
 	assert(type(func) == "function",
 		"value error: the first argument must be a function")
 	self.func = func
+	self.name = "Unnamed Command"
+	self.prio = cmdpriority.NORMAL
 	self.args = {select(1, ...)}
+	self.PRIORITY = nil
 end
 
 function Command:execute(time)
@@ -21,5 +30,24 @@ function Command:execute(time)
 	table.insert(args, time)
 	return self.func(unpack(args))
 end
+Command.PRIORITY = cmdpriority
 
-return Command
+local cmd = Command
+
+if _G.settings and _G.settings.server and
+   _G.settings.server.debug == true then
+	require("os")
+	local TimmedCommand = class(Command)
+	function TimmedCommand:execute(time)
+		local tstart = os.clock()
+		local rc = Command.execute(self, time)
+		dct.Logger.getByName("Command"):info(
+			string.format("'%s' exec time: %f",
+			self.name, os.clock()-tstart))
+		return rc
+	end
+	TimmedCommand.PRIORITY = cmdpriority
+	cmd = TimmedCommand
+end
+
+return cmd

--- a/src/dct/Theater.lua
+++ b/src/dct/Theater.lua
@@ -178,10 +178,18 @@ function Theater:_loadOrGenerate()
 end
 
 local function isPlayerGroup(grp, _, _)
+	local slotcnt = 0
 	for _, unit in ipairs(grp.units) do
 		if unit.skill == "Client" then
-			return true
+			slotcnt = slotcnt + 1
 		end
+	end
+	if slotcnt > 0 then
+		assert(slotcnt == 1,
+			string.format("DCT requires 1 slot groups. Group '%s' "..
+				" of type a/c (%s) has more than one player slot.",
+				grp.name, grp.units[1].type))
+		return true
 	end
 	return false
 end

--- a/src/dct/Theater.lua
+++ b/src/dct/Theater.lua
@@ -55,6 +55,7 @@ function Theater:__init()
 	self.cmdrs     = {}
 	self.scratchpad= {}
 	self.startdate = os.date("*t")
+	self._kicklist  = {}
 
 	for _, val in pairs(coalition.side) do
 		self.cmdrs[val] = Commander(self, val)
@@ -192,6 +193,17 @@ local function isPlayerGroup(grp, _, _)
 	end
 	return false
 end
+
+function Theater:queuekick(playerasset)
+	self._kicklist[playerasset.name] = true
+end
+
+function Theater:getkicklist()
+	local kicklist = self._kicklist
+	self._kicklist = {}
+	return json:encode(kicklist)
+end
+
 
 function Theater:_loadPlayerSlots()
 	local cnt = 0

--- a/src/dct/Theater.lua
+++ b/src/dct/Theater.lua
@@ -22,7 +22,6 @@ local Asset       = require("dct.Asset")
 local Commander   = require("dct.ai.Commander")
 local Command     = require("dct.Command")
 local Logger      = dct.Logger.getByName("Theater")
-local Profiler    = require("dct.libs.Profiler").getProfiler()
 local settings    = _G.dct.settings.server
 
 --[[
@@ -42,7 +41,6 @@ local settings    = _G.dct.settings.server
 local Theater = class(Observable)
 function Theater:__init()
 	Observable.__init(self)
-	Profiler:profileStart("Theater:init()")
 	self.savestatefreq = 7*60 -- seconds
 	self.cmdmindelay   = 2
 	self.uicmddelay    = self.cmdmindelay
@@ -66,11 +64,7 @@ function Theater:__init()
 	-- TODO: remove spawning from generation of the theater
 	self:_loadGoals()
 	self:_loadRegions()
-	self:_loadOrGenerate()
-	self:_loadPlayerSlots()
-	uiscratchpad(self)
-	self:queueCommand(100, Command(self.export, self))
-	Profiler:profileStop("Theater:init()")
+	self:queueCommand(20, Command(self._delayedInit, self))
 end
 
 function Theater.singleton()
@@ -79,6 +73,13 @@ function Theater.singleton()
 	end
 	_G.dct.theater = Theater()
 	return _G.dct.theater
+end
+
+function Theater:_delayedInit()
+	self:_loadOrGenerate()
+	self:_loadPlayerSlots()
+	uiscratchpad(self)
+	self:queueCommand(100, Command(self.export, self))
 end
 
 -- a description of the world state that signifies a particular side wins

--- a/src/dct/Theater.lua
+++ b/src/dct/Theater.lua
@@ -73,6 +73,14 @@ function Theater:__init()
 	Profiler:profileStop("Theater:init()")
 end
 
+function Theater.singleton()
+	if _G.dct.theater ~= nil then
+		return _G.dct.theater
+	end
+	_G.dct.theater = Theater()
+	return _G.dct.theater
+end
+
 -- a description of the world state that signifies a particular side wins
 -- TODO: create a common function that will read in a lua file like below
 -- verify it was read correctly, contains the token expected, returns the

--- a/src/dct/ai/Commander.lua
+++ b/src/dct/ai/Commander.lua
@@ -45,12 +45,11 @@ local Commander = class()
 
 function Commander:__init(theater, side)
 	self.owner        = side
-	self.theater      = theater
 	self.missionstats = Stats(genstatids())
 	self.missions     = {}
 	self.aifreq       = 300 -- seconds
 
-	self.theater:queueCommand(self.aifreq, Command(self.update, self))
+	theater:queueCommand(self.aifreq, Command(self.update, self))
 end
 
 function Commander:update(time)
@@ -158,7 +157,8 @@ function Commander:recommendMissionType(allowedmissions)
 		utils.mergetables(assetfilter, enum.missionTypeMap[v])
 	end
 
-	local pq = heapsort_tgtlist(self.theater:getAssetMgr(),
+	local pq = heapsort_tgtlist(
+		require("dct.Theater").singleton():getAssetMgr(),
 		self.owner, assetfilter)
 
 	local tgt = pq:pop()
@@ -185,7 +185,8 @@ end
 --   meets the mission criteria
 --]]
 function Commander:requestMission(grpname, missiontype)
-	local pq = heapsort_tgtlist(self.theater:getAssetMgr(),
+	local pq = heapsort_tgtlist(
+		require("dct.Theater").singleton():getAssetMgr(),
 		self.owner, enum.missionTypeMap[missiontype])
 
 	-- if no target, there is no mission to assign so return back
@@ -240,7 +241,7 @@ function Commander:getAssigned(asset)
 end
 
 function Commander:getAsset(name)
-	return self.theater:getAssetMgr():getAsset(name)
+	return require("dct.Theater").singleton():getAssetMgr():getAsset(name)
 end
 
 return Commander

--- a/src/dct/ai/Mission.lua
+++ b/src/dct/ai/Mission.lua
@@ -143,8 +143,8 @@ function Mission:update(_)
 			}
 			-- We have to use theater:queueCommand() to bypass the
 			-- limiting of players sending too many commands
-			self.cmdr.theater:queueCommand(10,
-				uicmds[request.type](self.cmdr.theater, request))
+			local theater = require("dct.Theater").singleton()
+			theater:queueCommand(10, uicmds[request.type](theater, request))
 		end
 	end
 	return

--- a/src/dct/assets/AssetBase.lua
+++ b/src/dct/assets/AssetBase.lua
@@ -23,6 +23,7 @@ local dctenum  = require("dct.enum")
 local dctutils = require("dct.utils")
 local Goal     = require("dct.Goal")
 local Marshallable = require("dct.libs.Marshallable")
+local Logger   = dct.Logger.getByName("Asset")
 local settings = _G.dct.settings
 
 local norenametype = {
@@ -74,6 +75,9 @@ local AssetBase = class(Marshallable)
 function AssetBase:__init(template, region)
 	if not self.__clsname then
 		self.__clsname = "AssetBase"
+	end
+	if not self._eventhandlers then
+		self._eventhandlers = {}
 	end
 	Marshallable.__init(self)
 	self:_addMarshalNames({
@@ -302,7 +306,14 @@ end
 -- Process a DCS event associated w/ this asset.
 -- Returns: none
 --]]
-function AssetBase:onDCSEvent(_ --[[event]])
+function AssetBase:onDCTEvent(event)
+	local handler = self._eventhandlers[event.id]
+	Logger:debug(string.format(
+		"AssetBase:onDCTEvent(%s); event.id: %d, handler: %s",
+		self.__clsname, event.id, tostring(handler)))
+	if handler ~= nil then
+		handler(self, event)
+	end
 end
 
 --[[

--- a/src/dct/assets/AssetManager.lua
+++ b/src/dct/assets/AssetManager.lua
@@ -15,8 +15,6 @@ local ASSET_CHECK_PERIOD = 12*60  -- seconds
 
 local AssetManager = class()
 function AssetManager:__init(theater)
-	self._theater = theater
-
 	-- The master list of assets, regardless of side, indexed by name.
 	-- Means Asset names must be globally unique.
 	self._assetset = {}
@@ -43,8 +41,8 @@ function AssetManager:__init(theater)
 	-- of their DCS objects with 'something', this will be the something.
 	self._object2asset = {}
 
-	self._theater:registerHandler(self.onDCSEvent, self)
-	self._theater:queueCommand(ASSET_CHECK_PERIOD,
+	theater:registerHandler(self.onDCSEvent, self)
+	theater:queueCommand(ASSET_CHECK_PERIOD,
 		Command(self.checkAssets, self))
 end
 
@@ -222,7 +220,7 @@ function AssetManager:onDCSEvent(event)
 		handler(self, event)
 	end
 
-	asset:onDCSEvent(event, self._theater)
+	asset:onDCSEvent(event)
 end
 
 function AssetManager:marshal()

--- a/src/dct/assets/Player.lua
+++ b/src/dct/assets/Player.lua
@@ -58,8 +58,8 @@ function Player:getLocation()
 	return self._location
 end
 
-local function handleBirth(self, event, theater)
-	--local theater = _G.dct.theater
+local function handleBirth(self, event)
+	local theater = require("dct.Theater").singleton()
 	local grp = event.initiator:getGroup()
 	local id = grp:getID()
 	if self.groupId ~= id then
@@ -95,10 +95,10 @@ local handlers = {
 	[world.event.S_EVENT_TAKEOFF] = handleTakeoff,
 }
 
-function Player:onDCSEvent(event, theater)
+function Player:onDCSEvent(event)
 	local handler = handlers[event.id]
 	if handler ~= nil then
-		handler(self, event, theater)
+		handler(self, event)
 	end
 end
 

--- a/src/dct/assets/Player.lua
+++ b/src/dct/assets/Player.lua
@@ -16,6 +16,18 @@ local Logger  = dct.Logger.getByName("Asset")
 local loadout = require("dct.systems.loadouts")
 local settings = _G.dct.settings
 
+--[[
+-- Player - represents a player slot in DCS
+--
+-- Slot Management
+--   Player objects cannot die however they can be spawned. Spawning
+--   is used as the signal for enabling/disabling the slot. The external
+--   hooks script will check if this object is spawned before allowing
+--   a player to enter the slot.
+--
+--   This covers disabling the other side is covering kicking a player
+--   from a slot.
+--]]
 local Player = class(AssetBase)
 function Player:__init(template, region)
 	self.__clsname = "Player"
@@ -86,6 +98,16 @@ end
 
 function Player:handleTakeoff(_ --[[event]])
 	loadout.kick(self)
+end
+
+--[[
+-- kick - cause the player to be removed from the slot
+--
+-- players are immediately removed from the slot, however, this
+-- action does not prevent another player from joing the slot
+--]]
+function Player:kick()
+	require("dct.Theater").singleton():queuekick(self)
 end
 
 return Player

--- a/src/dct/assets/Player.lua
+++ b/src/dct/assets/Player.lua
@@ -16,15 +16,13 @@ local Logger  = dct.Logger.getByName("Asset")
 local loadout = require("dct.systems.loadouts")
 local settings = _G.dct.settings
 
--- TODO: how to disable the player slot, we need to cover two cases:
---  * disabled: a player cannot enter the slot but if already occupied
---    the player is not removed from the slot
---  * kick: players are immediately removed from the slot and
---    new players are prevented from joining
-
 local Player = class(AssetBase)
 function Player:__init(template, region)
 	self.__clsname = "Player"
+	self._eventhandlers = {
+		[world.event.S_EVENT_BIRTH]   = self.handleBirth,
+		[world.event.S_EVENT_TAKEOFF] = self.handleTakeoff,
+	}
 	AssetBase.__init(self, template, region)
 	self:_addMarshalNames({
 		"unittype",
@@ -58,7 +56,7 @@ function Player:getLocation()
 	return self._location
 end
 
-local function handleBirth(self, event)
+function Player:handleBirth(event)
 	local theater = require("dct.Theater").singleton()
 	local grp = event.initiator:getGroup()
 	local id = grp:getID()
@@ -86,20 +84,8 @@ local function handleBirth(self, event)
 	loadout.notify(grp)
 end
 
-local function handleTakeoff(_, event)
+function Player:handleTakeoff(event)
 	loadout.kick(event.initiator:getGroup())
-end
-
-local handlers = {
-	[world.event.S_EVENT_BIRTH] = handleBirth,
-	[world.event.S_EVENT_TAKEOFF] = handleTakeoff,
-}
-
-function Player:onDCSEvent(event)
-	local handler = handlers[event.id]
-	if handler ~= nil then
-		handler(self, event)
-	end
 end
 
 return Player

--- a/src/dct/assets/Player.lua
+++ b/src/dct/assets/Player.lua
@@ -66,26 +66,26 @@ function Player:handleBirth(event)
 				self.name, self.groupId, id))
 	end
 	self.groupId = id
-	uimenu.createMenu(theater, self)
+	uimenu.createMenu(self)
 	local cmdr = theater:getCommander(grp:getCoalition())
 	local msn  = cmdr:getAssigned(self)
 
 	if msn then
-		trigger.action.outTextForGroup(grp:getID(),
+		trigger.action.outTextForGroup(self.groupId,
 			"Welcome. A mission is already assigned to this slot, "..
 			"use the F10 menu to get the briefing or find another.",
 			20, false)
 	else
-		trigger.action.outTextForGroup(grp:getID(),
+		trigger.action.outTextForGroup(self.groupId,
 			"Welcome. Use the F10 Menu to get a theater update and "..
 			"request a mission.",
 			20, false)
 	end
-	loadout.notify(grp)
+	loadout.notify(self)
 end
 
-function Player:handleTakeoff(event)
-	loadout.kick(event.initiator:getGroup())
+function Player:handleTakeoff(_ --[[event]])
+	loadout.kick(self)
 end
 
 return Player

--- a/src/dct/assets/StaticAsset.lua
+++ b/src/dct/assets/StaticAsset.lua
@@ -23,6 +23,9 @@ function StaticAsset:__init(template, region)
 	self._curdeathgoals = 0
 	self._deathgoals    = {}
 	self._assets        = {}
+	self._eventhandlers = {
+		[world.event.S_EVENT_DEAD] = self.handleDead,
+	}
 	AssetBase.__init(self, template, region)
 	self:_addMarshalNames({
 		"_hasDeathGoals",
@@ -171,14 +174,7 @@ function StaticAsset:getObjectNames()
 	return keyset
 end
 
-function StaticAsset:onDCSEvent(event)
-	-- only handle DEAD events
-	if event.id ~= world.event.S_EVENT_DEAD then
-		Logger:debug(string.format("onDCSEvent() - StaticAsset(%s)"..
-		" not DEAD event, ignoring", self.name))
-		return
-	end
-
+function StaticAsset:handleDead(event)
 	local obj = event.initiator
 
 	-- mark the unit/group/static as dead in the template, dct_dead

--- a/src/dct/init.lua
+++ b/src/dct/init.lua
@@ -5,11 +5,16 @@
 --]]
 
 local Theater = require("dct.Theater")
+local runonce
 
 local function init()
-	local t = Theater()
+	if runonce == true then
+		return
+	end
+	local t = Theater.singleton()
 	world.addEventHandler(t)
 	timer.scheduleFunction(t.exec, t, timer.getTime() + 20)
+	runonce = true
 end
 
 return init

--- a/src/dct/systems/loadouts.lua
+++ b/src/dct/systems/loadouts.lua
@@ -59,27 +59,30 @@ local notifymsg =
 	"use the F10 Menu to validate your loadout before departing."
 local loadout = {}
 
-function loadout.notify(grp)
-	trigger.action.outTextForGroup(grp:getID(), notifymsg, 20, false)
+function loadout.notify(player)
+	trigger.action.outTextForGroup(player.groupId, notifymsg, 20, false)
 end
 
-function loadout.kick(grp, limits)
-	local ok = validatePayload(grp, limits)
+function loadout.kick(player)
+	local ok = validatePayload(Group.getByName(player.name),
+		player.payloadlimits)
 	if ok then
 		return
 	end
 
-	trigger.action.outTextForGroup(grp:getID(),
+	trigger.action.outTextForGroup(player.groupId,
 		"You have been removed to spectator for flying with an "..
 		"invalid loadout. "..notifymsg,
 		20, true)
-	trigger.action.setUserFlag(grp:getName(), 100)
+	trigger.action.setUserFlag(player.name, 100)
+	player:kick()
 	return ok
 end
 
-function loadout.check(grp, limits)
+function loadout.check(player)
 	local msg
-	local ok, costs = validatePayload(grp, limits)
+	local ok, costs = validatePayload(Group.getByName(player.name),
+		player.payloadlimits)
 	if ok then
 		msg = "Valid loadout, you may depart. Good luck!"
 	else

--- a/src/dct/templates/STM.lua
+++ b/src/dct/templates/STM.lua
@@ -122,7 +122,7 @@ end
 --    }}}
 --]]
 
-function STM.transform(stmdata)
+function STM.transform(stmdata, file)
 	local template   = {}
 	local lookupname =  function(name)
 		assert(name and type(name) == "string",
@@ -139,10 +139,13 @@ function STM.transform(stmdata)
 		if template.coalition == nil then
 			template.coalition = side
 		end
-		assert(template.coalition == side,
-			"runtime error: invalid template STM; country("..cntryid..")"..
-			" does not belong to template.coalition("..template.coalition..
-			"), country belongs to "..side)
+		assert(template.coalition == side, string.format(
+			"runtime error: invalid STM; country(%s) does not belong "..
+			"to '%s' coalition, country belongs to '%s' coalition; file: %s",
+			country.name[cntryid],
+			utils.getkey(coalition.side, template.coalition),
+			utils.getkey(coalition.side, side),
+			file))
 		return true
 	end
 

--- a/src/dct/ui/cmds.lua
+++ b/src/dct/ui/cmds.lua
@@ -121,8 +121,7 @@ function CheckPayloadCmd:__init(theater, data)
 end
 
 function CheckPayloadCmd:_execute(_ --[[time]], _ --[[cmdr]])
-	local msg = loadout.check(Group.getByName(self.grpname),
-		self.asset.payloadlimits)
+	local msg = loadout.check(self.asset)
 	return msg
 end
 

--- a/src/dct/ui/cmds.lua
+++ b/src/dct/ui/cmds.lua
@@ -24,12 +24,8 @@ function UICmd:__init(theater, data)
 	self.theater      = theater
 	self.asset        = asset
 	self.type         = data.type
-	self.grpid        = asset.groupId
-	self.grpname      = data.name
-	self.side         = asset.owner
 	self.displaytime  = 30
 	self.displayclear = true
-	self.actype       = asset.unittype
 end
 
 function UICmd:isAlive()
@@ -47,11 +43,11 @@ function UICmd:execute(time)
 		return nil
 	end
 
-	local cmdr = self.theater:getCommander(self.side)
+	local cmdr = self.theater:getCommander(self.asset.owner)
 	local msg  = self:_execute(time, cmdr)
 	assert(msg ~= nil and type(msg) == "string", "msg must be a string")
-	trigger.action.outTextForGroup(self.grpid, msg, self.displaytime,
-		self.displayclear)
+	trigger.action.outTextForGroup(self.asset.groupId, msg,
+		self.displaytime, self.displayclear)
 	self.asset.cmdpending = false
 	return nil
 end
@@ -74,12 +70,12 @@ end
 
 function ScratchPadSet:_execute(_, _)
 	local mrkid = human.getMarkID()
-	local pos   = Group.getByName(self.grpname):getUnit(1):getPoint()
-	local title = "SCRATCHPAD "..tostring(self.grpid)
+	local pos   = Group.getByName(self.asset.name):getUnit(1):getPoint()
+	local title = "SCRATCHPAD "..tostring(self.asset.groupId)
 
-	self.theater.scratchpad[mrkid] = self.grpname
-	trigger.action.markToGroup(mrkid, title, pos, self.grpid, false,
-		"edit me")
+	self.theater.scratchpad[mrkid] = self.asset.name
+	trigger.action.markToGroup(mrkid, title, pos, self.asset.groupId,
+		false, "edit me")
 	local msg = "Look on F10 MAP for user mark with title: "..
 		title.."\n"..
 		"Edit body with your scratchpad information. "..
@@ -208,7 +204,7 @@ function MissionRqstCmd:_execute(_, cmdr)
 		return msg
 	end
 
-	msn = cmdr:requestMission(self.grpname, self.missiontype)
+	msn = cmdr:requestMission(self.asset.name, self.missiontype)
 	if msn == nil then
 		msg = string.format("No %s missions available.",
 			human.missiontype(self.missiontype))
@@ -216,7 +212,7 @@ function MissionRqstCmd:_execute(_, cmdr)
 		msg = string.format("Mission %s assigned, use F10 menu "..
 			"to see this briefing again\n", msn:getID())
 		msg = msg..briefingmsg(msn, self.asset)
-		human.drawTargetIntel(msn, self.grpid, false)
+		human.drawTargetIntel(msn, self.asset.groupId, false)
 	end
 	return msg
 end

--- a/src/dct/ui/groupmenu.lua
+++ b/src/dct/ui/groupmenu.lua
@@ -25,7 +25,8 @@ local addmenu = missionCommands.addSubMenuForGroup
 local addcmd  = missionCommands.addCommandForGroup
 
 local menus = {}
-function menus.createMenu(theater, asset)
+function menus.createMenu(asset)
+	local theater = require("dct.Theater").singleton()
 	local gid  = asset.groupId
 	local name = asset.name
 

--- a/tests/runtests
+++ b/tests/runtests
@@ -32,7 +32,7 @@ fi
 
 for t in $tests; do
 	result="PASS"
-	./${t}
+	./$(basename ${t})
 	if test $? -ne 0; then
 		result="FAIL"
 		fail=1

--- a/tests/test-0003-class.lua
+++ b/tests/test-0003-class.lua
@@ -1,0 +1,36 @@
+#!/usr/bin/lua
+
+require("os")
+require("io")
+local class = require("libs.class")
+--local json  = require("libs.json")
+local instance
+
+local A = class()
+function A:__init()
+    self.a = 2
+    self.b = 3
+end
+
+function A.instance()
+    if instance ~= nil then
+        --print("instance set")
+        return instance
+    end
+    instance = A()
+    --print("should run once")
+    return instance
+end
+
+local function main()
+    local a = A.instance()
+    local b = A.instance()
+    b.b = 5
+    assert(a == b, "singleton broken?")
+    --print("a: "..json:encode_pretty(a))
+    --print("b: "..json:encode_pretty(b))
+    --print("a: "..tostring(a).."; b: "..tostring(b)..
+    --    "; instance: "..tostring(instance))
+end
+
+os.exit(main())

--- a/tests/test-all-templates.lua
+++ b/tests/test-all-templates.lua
@@ -2,14 +2,10 @@
 
 require("math")
 require("dcttestlibs")
-dctsettings = {
-	["profile"] = true,
-	["debug"]   = false,
-	["logger"]  = {
-	},
-	["theaterpath"] = os.getenv("DCT_TEMPLATE_PATH"),
-}
 require("dct")
+dct.settings.server.profile = true
+dct.settings.server.debug   = false
+dct.settings.server.theaterpath = os.getenv("DCT_TEMPLATE_PATH")
 
 local function main()
 	-- setup an initial seed, lets use the same one for now '12345'

--- a/tests/test-all-templates.lua
+++ b/tests/test-all-templates.lua
@@ -16,6 +16,7 @@ local function main()
 	end
 
 	local t = dct.Theater()
+	t:exec(50)
 	local Logger = dct.Logger.getByName("Tests")
 	Logger:debug("Groups spawned:  "..dctcheck.spawngroups)
 	Logger:debug("Statics spawned: "..dctcheck.spawnstatics)

--- a/tests/test-events.lua
+++ b/tests/test-events.lua
@@ -74,6 +74,7 @@ local function main()
 		},
 	}, playergrp, "bobplayer")
 
+	t:exec(50)
 	t:getAssetMgr():checkAssets(2000)
 
 	for _, data in ipairs(testcases) do

--- a/tests/test-events.lua
+++ b/tests/test-events.lua
@@ -1,13 +1,9 @@
 #!/usr/bin/lua
 
 require("dcttestlibs")
-dctsettings = {
-	["profile"] = false,
-	["debug"]   = false,
-	["logger"]  = {
-	},
-}
 require("dct")
+dct.settings.server.profile = false
+dct.settings.server.debug   = false
 
 local testcases = {
 	[1] = {

--- a/tests/test-init.lua
+++ b/tests/test-init.lua
@@ -6,6 +6,7 @@ require("dct")
 
 local function main()
 	dct.init()
+	_G.dct.theater:exec(50)
 	assert(dctcheck.spawngroups == 1, "group spawn broken")
 	assert(dctcheck.spawnstatics == 11, "static spawn broken")
 	return 0

--- a/tests/test-theater.lua
+++ b/tests/test-theater.lua
@@ -7,6 +7,7 @@ require("dcttestlibs")
 require("dct")
 local enum   = require("dct.enum")
 local settings = _G.dct.settings.server
+local DEBUG = false
 
 local events = {
 	{
@@ -168,7 +169,14 @@ local events = {
 	},
 }
 
-
+local function copyfile(src, dest)
+	local json = require("libs.json")
+	local orig = io.open(src, "r")
+	local save = io.open(dest, "w")
+	save:write(json:encode_pretty(json:decode(orig:read("*a"))))
+	orig:close()
+	save:close()
+end
 
 local function createEvent(eventdata, player)
 	local event = {}
@@ -244,12 +252,15 @@ local function main()
 	local f = io.open(settings.statepath, "r")
 	local sumorig = md5.sum(f:read("*all"))
 	f:close()
+	if DEBUG == true then
+		copyfile(settings.statepath, settings.statepath..".orig")
+	end
 
 	local newtheater = dct.Theater()
 	local name = "Test region_1_Abu Musa Ammo Dump"
 	-- verify the units read in do not include the asset we killed off
 	assert(newtheater:getAssetMgr():getAsset(name) == nil,
-		"state saving has an issue")
+		"state saving has an issue, dead asset is alive: "..name)
 
 	-- attempt to get theater status
 	newtheater:onEvent({
@@ -278,6 +289,9 @@ local function main()
 	f = io.open(settings.statepath, "r")
 	local sumsave = md5.sum(f:read("*all"))
 	f:close()
+	if DEBUG == true then
+		copyfile(settings.statepath, settings.statepath..".new")
+	end
 	os.remove(settings.statepath)
 
 	assert(newtheater.statef == true and sumorig == sumsave,

--- a/tests/test-theater.lua
+++ b/tests/test-theater.lua
@@ -226,6 +226,7 @@ local function main()
 	}, playergrp, "bobplayer")
 
 	local theater = dct.Theater()
+	_G.dct.theater = theater
 	theater:exec(50)
 	assert(dctcheck.spawngroups == 1,
 		string.format("group spawn broken; expected(%d), got(%d)",
@@ -258,6 +259,7 @@ local function main()
 	end
 
 	local newtheater = dct.Theater()
+	_G.dct.theater = newtheater
 	newtheater:exec(50)
 	local name = "Test region_1_Abu Musa Ammo Dump"
 	-- verify the units read in do not include the asset we killed off

--- a/tests/test-theater.lua
+++ b/tests/test-theater.lua
@@ -226,6 +226,7 @@ local function main()
 	}, playergrp, "bobplayer")
 
 	local theater = dct.Theater()
+	theater:exec(50)
 	assert(dctcheck.spawngroups == 1,
 		string.format("group spawn broken; expected(%d), got(%d)",
 		1, dctcheck.spawngroups))
@@ -257,6 +258,7 @@ local function main()
 	end
 
 	local newtheater = dct.Theater()
+	newtheater:exec(50)
 	local name = "Test region_1_Abu Musa Ammo Dump"
 	-- verify the units read in do not include the asset we killed off
 	assert(newtheater:getAssetMgr():getAsset(name) == nil,

--- a/tests/test-theater.lua
+++ b/tests/test-theater.lua
@@ -218,8 +218,12 @@ local function main()
 	}, playergrp, "bobplayer")
 
 	local theater = dct.Theater()
-	assert(dctcheck.spawngroups == 1, "group spawn broken")
-	assert(dctcheck.spawnstatics == 11, "static spawn broken")
+	assert(dctcheck.spawngroups == 1,
+		string.format("group spawn broken; expected(%d), got(%d)",
+		1, dctcheck.spawngroups))
+	assert(dctcheck.spawnstatics == 11,
+		string.format("static spawn broken; expected(%d), got(%d)",
+		11, dctcheck.spawnstatics))
 
 	--[[ TODO: test ATO once support is added for squadron
 	local restriction =

--- a/tests/test-ui-cmds.lua
+++ b/tests/test-ui-cmds.lua
@@ -127,6 +127,7 @@ local testcmds = {
 
 local function main()
 	local theater = dct.Theater()
+	theater:exec(50)
 	theater:onEvent({
 		["id"]        = world.event.S_EVENT_BIRTH,
 		["initiator"] = unit1,

--- a/tests/test-ui-cmds.lua
+++ b/tests/test-ui-cmds.lua
@@ -127,6 +127,7 @@ local testcmds = {
 
 local function main()
 	local theater = dct.Theater()
+	_G.dct.theater = theater
 	theater:exec(50)
 	theater:onEvent({
 		["id"]        = world.event.S_EVENT_BIRTH,

--- a/tests/test-ui-cmds.lua
+++ b/tests/test-ui-cmds.lua
@@ -2,9 +2,7 @@
 
 require("math")
 math.randomseed(50)
-
 require("dcttestlibs")
-
 require("dct")
 local enum   = require("dct.enum")
 local uicmds = require("dct.ui.cmds")

--- a/tests/test-ui-cmds2.lua
+++ b/tests/test-ui-cmds2.lua
@@ -49,6 +49,7 @@ local testcmds = {
 
 local function main()
 	local theater = dct.Theater()
+	theater:exec(50)
 	-- We need to send a birth event to populate the Theater.playergps table
 	theater:onEvent({
 		["id"]        = world.event.S_EVENT_BIRTH,

--- a/tests/test-ui-cmds2.lua
+++ b/tests/test-ui-cmds2.lua
@@ -49,6 +49,7 @@ local testcmds = {
 
 local function main()
 	local theater = dct.Theater()
+	_G.dct.theater = theater
 	theater:exec(50)
 	-- We need to send a birth event to populate the Theater.playergps table
 	theater:onEvent({

--- a/tests/test-ui-cmds2.lua
+++ b/tests/test-ui-cmds2.lua
@@ -2,11 +2,9 @@
 
 require("math")
 math.randomseed(50)
-
 require("dcttestlibs")
-
 require("dct")
-local enum   = require("dct.enum")
+local enum = require("dct.enum")
 
 -- create a player group
 local grp = Group(4, {

--- a/tests/test-ui-groupmenu.lua
+++ b/tests/test-ui-groupmenu.lua
@@ -38,6 +38,7 @@ local testcmds = {
 
 local function main()
 	local theater = dct.Theater()
+	theater:exec(50)
 	for _, data in ipairs(testcmds) do
 		trigger.action.setmsgbuffer(data.expect)
 		theater:onEvent(data.event)

--- a/tests/test-ui-groupmenu.lua
+++ b/tests/test-ui-groupmenu.lua
@@ -38,6 +38,7 @@ local testcmds = {
 
 local function main()
 	local theater = dct.Theater()
+	_G.dct.theater = theater
 	theater:exec(50)
 	for _, data in ipairs(testcmds) do
 		trigger.action.setmsgbuffer(data.expect)

--- a/tests/test-ui-groupmenu.lua
+++ b/tests/test-ui-groupmenu.lua
@@ -1,6 +1,5 @@
 #!/usr/bin/lua
 
---[[
 require("dcttestlibs")
 require("dct")
 
@@ -31,8 +30,9 @@ local testcmds = {
 			["initiator"] = unit1,
 		},
 		["assert"] = true,
-		["expect"] = "Welcome. Use the F10 Menu to get a theater "..
-			"update and request a mission.",
+		["expect"] = "Please read the loadout limits in the briefing"..
+			" and use the F10 Menu to validate your loadout before"..
+			" departing.",
 	},
 }
 
@@ -45,6 +45,5 @@ local function main()
 	end
 	return 0
 end
---]]
 
-os.exit(0)
+os.exit(main())


### PR DESCRIPTION
Miscellaneous changes to facilitate squadrons feature. We change the Theater class to be a singleton, delay the spawning of assets, and stop passing a theater reference everywhere.

The delaying of spawning assets allows the Theater class constructor to complete so that we have an instance of the Theater class to reference when assets are spawned. This is important when "generator" assets generate and spawn additional assets in their spawn function.

We no longer need to pass a reference to the theater class everywhere as now the Theater class is a singleton and just calling Theater.singleton() will simply give us the same global object.