### PR TITLE
template: allow some assets to regenerate

### DIFF
--- a/data/mission/theater/region1/base-defense/BandarEJaskAirbaseDefence.dct
+++ b/data/mission/theater/region1/base-defense/BandarEJaskAirbaseDefence.dct
@@ -1,6 +1,6 @@
 metadata = {
 	["rank"]     = 2,
 	["objtype"]  = "basedefense",
-
 	["base"]     = "Bandar-e-jask airfield",
+	["regenerate"] = true,
 }

--- a/doc/03-designer.md
+++ b/doc/03-designer.md
@@ -690,6 +690,15 @@ ignored by the DCT AI. This includes scheduling the asset to be assigned
 as a target to a player. [TODO] This will also make any units spawned
 by the asset to be ignored by the DCS AI.
 
+### `regenerate`
+
+ * _required:_ no
+ * _value:_ boolean
+ * _default:_ false
+
+Forces an asset on state reload to reset its `tpldata` to the original
+state when the asset was created.
+
 ### Attributes - Type Specific
 
 #### Airspace

--- a/src/dct/assets/AssetBase.lua
+++ b/src/dct/assets/AssetBase.lua
@@ -121,6 +121,7 @@ function AssetBase:__init(template, region)
 		"codename",
 		"cost",
 		"ignore",
+		"regenerate",
 	})
 	self._spawned    = false
 	self._dead       = false
@@ -154,6 +155,7 @@ function AssetBase:_completeinit(template, region)
 		print(string.format("Template(%s) has nil 'desc' field",
 			template.name))
 	end
+	self.regenerate = template.regenerate
 	self.ignore   = template.ignore
 	self.owner    = template.coalition
 	self.rgnname  = region.name

--- a/src/dct/assets/StaticAsset.lua
+++ b/src/dct/assets/StaticAsset.lua
@@ -300,7 +300,11 @@ function StaticAsset:marshal()
 	if tbl == nil then
 		return nil
 	end
-	tbl._tpldata = filterTemplateData(self._tpldata)
+	if self.regenerate then
+		tbl._tpldata = self._tpldata
+	else
+		tbl._tpldata = filterTemplateData(self._tpldata)
+	end
 	if tbl._tpldata == nil then
 		return nil
 	end

--- a/src/dct/templates/Template.lua
+++ b/src/dct/templates/Template.lua
@@ -261,6 +261,10 @@ local function getkeys(objtype)
 			["type"]    = "boolean",
 			["default"] = false,
 		}, {
+			["name"]    = "regenerate",
+			["type"]    = "boolean",
+			["default"] = false,
+		}, {
 			["name"]    = "priority",
 			["type"]    = "number",
 			["default"] = enum.assetTypePriority[objtype] or 1000,


### PR DESCRIPTION
Define a new template attribute `regenerate` that when `true` will cause the
given asset to lookup the template it was based off of and copy over the
`tpldata` again.

Currently only StaticAssets comply with this setting as no other assets
utilize tpldata in any meaningful way.

Closes: #117