### PR TITLE
Feature: add map marker for player when joining a mission

### DIFF
--- a/src/dct/ui/cmds.lua
+++ b/src/dct/ui/cmds.lua
@@ -212,6 +212,7 @@ function MissionJoinCmd:_execute(_, cmdr)
 		msg = string.format("Mission %s assigned, use F10 menu "..
 			"to see this briefing again\n", msn:getID())
 		msg = msg..briefingmsg(msn, self.asset)
+		human.drawTargetIntel(msn, self.asset.groupId, false)
 	end
 	return msg
 end


### PR DESCRIPTION
Minor change to create target markers to players that join an ongoing mission, which is currently only visible to the player which originally requested it.

Test done by requesting a mission from slot A, noting the marker created by DCT, switching to slot B, noting the marker is not available in the new slot, and then joining the mission via A's mission code, which now creates a marker for slot B.
