### PR TITLE
systems: rework how systems register with theater

### DIFF
--- a/src/dct/systems/tickets.lua
+++ b/src/dct/systems/tickets.lua
@@ -94,9 +94,10 @@ local function checkside(keydata, tbl)
 end
 
 local Tickets = class(Marshallable)
-function Tickets:__init(theater, filepath)
+function Tickets:__init(theater)
 	Marshallable.__init(self)
-	self.cfgfile = filepath
+	self.cfgfile = dct.settings.server.theaterpath..utils.sep..
+		"theater.goals"
 	self.tickets = {}
 	self.timeout = {
 		["enabled"] = false,


### PR DESCRIPTION
This changes how systems register with the theater to a component object
model. Making common how one accesses an instance of a system in the
theater and registering a system with the theater. This also forces
a common API that each system must provide:

  * must be a class and the init accepts a single argument, an instance
    of the theater
  * if the system needs to save state it just needs to implement the
    Marshallable interface

Finally this change removes the pollution of the Theater with individual
member objects, they are now all contained under `Theater.systems`.