### PR TITLE
systems: while restoring state ignore scenery events

### DIFF
--- a/src/dct/Theater.lua
+++ b/src/dct/Theater.lua
@@ -134,6 +134,14 @@ function Theater:addSystem(path)
 	Logger:info("init "..path)
 end
 
+function Theater:postinitSystems()
+	for _, sys in pairs(self._systems) do
+		if type(sys.initpost) == "function" then
+			sys:initpost(self)
+		end
+	end
+end
+
 function Theater:loadSystems()
 	local systems = {
 		"dct.ui.scratchpad",
@@ -232,6 +240,7 @@ end
 function Theater:delayedInit()
 	self:loadPlayerSlots()
 	self:loadOrGenerate()
+	self:postinitSystems()
 end
 
 -- DCS looks for this function in any table we register with the world

--- a/src/dct/assets/StaticAsset.lua
+++ b/src/dct/assets/StaticAsset.lua
@@ -180,6 +180,10 @@ function StaticAsset:handleDead(event)
 		end
 	else
 		self._assets[unitname].data.dct_dead = true
+		if self._assets[unitname].category == enum.UNIT_CAT_SCENERY then
+			dct.Theater.singleton():getSystem(
+				"dct.systems.bldgPersist"):addObject(unitname)
+		end
 		local goal = self._deathgoals[unitname]
 		if goal and goal:checkComplete() then
 			self:_removeDeathGoal(unitname, goal)


### PR DESCRIPTION
Also, change the storage of scenery ids to be a set instead of a list.

Closes: #149