### PR TITLE
Feature slot expire

### DIFF
--- a/src/dct/ai/Commander.lua
+++ b/src/dct/ai/Commander.lua
@@ -242,13 +242,13 @@ function Commander:getAssigned(asset)
 	local msn = self.missions[asset.missionid]
 
 	if msn == nil then
-		asset.missionid = 0
+		asset.missionid = enum.misisonInvalidID
 		return nil
 	end
 
 	local member = msn:isMember(asset.name)
 	if not member then
-		asset.missionid = 0
+		asset.missionid = enum.misisonInvalidID
 		return nil
 	end
 	return msn

--- a/src/dct/ai/Mission.lua
+++ b/src/dct/ai/Mission.lua
@@ -85,7 +85,7 @@ function Mission:removeAssigned(asset)
 		return
 	end
 	table.remove(self.assigned, i)
-	asset.missionid = 0
+	asset.missionid = enum.misisonInvalidID
 end
 
 --[[

--- a/src/dct/assets/Player.lua
+++ b/src/dct/assets/Player.lua
@@ -102,6 +102,28 @@ end
 
 function EmptyState:enter(asset)
 	asset:kick(self.kickcode)
+	if asset.missionid ~= dctenum.missionInvalidID and
+	   settings.server.emptyslottimeout > 0 then
+		self.timer =
+			require("dct.libs.Timer")(settings.server.emptyslottimeout,
+				timer.getAbsTime)
+	end
+end
+
+function EmptyState:update(asset)
+	if self.timer == nil then
+		return
+	end
+
+	self.timer:update()
+	if self.timer:expired() then
+		self.timer = nil
+		local cmdr = dct.Theater.singleton():getCommander(asset.owner)
+		local msn = cmdr:getMission(asset.missionid)
+		if msn then
+			msn:abort(asset)
+		end
+	end
 end
 
 function EmptyState:onDCTEvent(asset, event)
@@ -250,6 +272,7 @@ local Player = class("Player", AssetBase)
 function Player:__init(template, region)
 	AssetBase.__init(self, template, region)
 	self._operstate = false
+	self.missionid = dctenum.missionInvalidID
 	trigger.action.setUserFlag(self.name, false)
 	trigger.action.setUserFlag(build_kick_flagname(self.name),
 		dctenum.kickCode.NOKICK)

--- a/src/dct/enum.lua
+++ b/src/dct/enum.lua
@@ -71,6 +71,8 @@ enum.assetTypePriority = {
 	[enum.assetType.KEEPOUT]     = 10000,
 }
 
+enum.missionInvalidID = 0
+
 enum.missionType = {
 	["CAS"]      = 1,
 	["CAP"]      = 2,

--- a/src/dct/settings/server.lua
+++ b/src/dct/settings/server.lua
@@ -86,6 +86,10 @@ local function validate_server_config(cfgdata, tbl)
 			["name"] = "dctid",
 			["type"] = "string",
 			["default"] = cfgdata.default["dctid"],
+		}, {
+			["name"] = "emptyslottimeout",
+			["type"] = "number",
+			["default"] = cfgdata.default["emptyslottimeout"],
 		},
 	}
 	tbl.path = cfgdata.file
@@ -131,6 +135,7 @@ local function servercfgs(config)
 				["statServerHostname"] = "localhost",
 				["statServerPort"] = 8095,
 				["dctid"] = "changeme",
+				["emptyslottimeout"] = 0, -- seconds
 			},
 		},}, config)
 	return config


### PR DESCRIPTION
When a player leaves a slot start a timer if the slot is assigned to a mission. Upon the expiration of the timer remove the slot from the assigned mission. Allow the server administrator the ability to adjust when empty slots should expire from an assigned mission. To preserve previous behaviour slot expiration is left off and slots will be removed when the mission expires. It is up to the administrator to setup a shorter slot expiration.
