### PR TITLE
libs: implement a generic timer class

### DIFF
--- a/src/dct/libs/Timer.lua
+++ b/src/dct/libs/Timer.lua
@@ -1,0 +1,54 @@
+--[[
+-- SPDX-License-Identifier: LGPL-3.0
+--
+-- A count-up Timer
+--
+-- interface:
+--   * reset   - reset timer to zero
+--   * update  - update the timer, uses timefunc to determine the elapsed time
+--               between updates
+--   * expired - has the timer reached its timeout limit
+--   * remain  - how many seconds remain
+--   * extend  - extend the timer by 'time' time
+--]]
+
+local Timer = require("libs.namedclass")("Timer")
+function Timer:__init(timeout, timefunc)
+	self.timefunc = timefunc or timer.getAbsTime
+	assert(type(self.timefunc) == "function", "timefunc must be a function")
+	assert(type(timeout) == "number" and timeout > 0,
+		"timeout must be a number and greater than zero")
+	self.timeoutlimit = timeout
+	self.timeout = 0
+	self.curtime = self.timefunc()
+end
+
+function Timer:reset(limit)
+	self.timeoutlimit = limit or self.timeoutlimit
+	self.timeout = 0
+	self.curtime = self.timefunc()
+end
+
+function Timer:update()
+	local prevtime = self.curtime
+	self.curtime = self.timefunc()
+	self.timeout = self.timeout + (self.curtime - prevtime)
+end
+
+function Timer:expired()
+	return self.timeout > self.timeoutlimit
+end
+
+function Timer:remain()
+	local remain = self.timeoutlimit - self.timeout
+	if remain < 0 then
+		remain = 0
+	end
+	return remain, self.curtime
+end
+
+function Timer:extend(time)
+	self.timeoutlimit = self.timeoutlimit + time
+end
+
+return Timer

--- a/tests/test-0005-timer.lua
+++ b/tests/test-0005-timer.lua
@@ -1,0 +1,33 @@
+#!/usr/bin/lua
+
+require("os")
+local Timer = require("dct.libs.Timer")
+
+local function sleep(s)
+	local n = os.clock() + s
+	repeat until os.clock() > n
+end
+
+local function main()
+	local a = Timer(15, os.clock)
+	local b = Timer(2, os.clock)
+
+	sleep(3)
+	a:update()
+	b:update()
+	local remain = a:remain()
+	assert(remain <= 12, "remain: "..remain)
+	assert(a:expired() == false)
+
+	remain = b:remain()
+	assert(remain == 0, "remain: "..remain)
+	assert(b:expired() == true)
+	b:reset()
+	remain = b:remain()
+	assert(remain == 2, "remain: "..remain)
+	b:extend(2)
+	remain = b:remain()
+	assert(remain == 4, "extend failed")
+end
+
+os.exit(main())


### PR DESCRIPTION
This count up timer takes the timeout and will count the amount of time
elapsed since the last call to update(). Once elapsed time is greater
than timeout the timer has expired. The timer notes the current time
using timefunc and then takes the difference between the last time
and the current time to figure out the elapsed time since the last
call to update().

This timer does not handle roll overs of the underlying timefunc.