### PR TITLE
Fix spelling of Caucasus in timezone table

### DIFF
--- a/src/dct/utils.lua
+++ b/src/dct/utils.lua
@@ -72,7 +72,7 @@ local offsettbl = {
 	["Test Theater"] =  6*3600, -- simulate US Central TZ
 	["PersianGulf"]  = -4*3600,
 	["Nevada"]       =  8*3600,
-	["Caucuses"]     = -4*3600,
+	["Caucasus"]     = -4*3600,
 	["Normandy"]     = -1*3600,
 }
 


### PR DESCRIPTION
The correct spelling was verified by extracting the theatre file from a .miz that uses the map