### PR TITLE
Changed mergeTables to give DCT priority over STM when values in both.

### DIFF
--- a/src/dct/templates/Template.lua
+++ b/src/dct/templates/Template.lua
@@ -423,8 +423,8 @@ function Template.fromFile(regionname, dctfile, stmfile)
 	template.regionname = regionname
 	template.path = dctfile
 	if stmfile ~= nil then
-		template = utils.mergetables(template,
-			STM.transform(utils.readlua(stmfile, "staticTemplate")))
+		template = utils.mergetables(
+		STM.transform(utils.readlua(stmfile, "staticTemplate")),template)
 	end
 	return Template(template)
 end


### PR DESCRIPTION
Reversed order of variables passed to the function to make DCT File contents take priority over STM file contents. DCT file is the user created file so it makes sense that variables manually defined within it should take priority.