### PR TITLE
Added ability to define custom codenames for assets in .dct.

### DIFF
--- a/src/dct/assets/AssetBase.lua
+++ b/src/dct/assets/AssetBase.lua
@@ -170,8 +170,11 @@ function AssetBase:_completeinit(template, region)
 				dct.Theater.singleton():getcntr()
 		end
 	end
-	self.codename = generateCodename(self.type)
-
+	if template.codename ~= "default codename" then
+		self.codename = template.codename
+	else
+		self.codename = generateCodename(self.type)
+	end
 	self._intel[self.owner] = dctutils.INTELMAX
 	if self.owner ~= coalition.side.NEUTRAL and template.intel then
 		self._intel[dctutils.getenemy(self.owner)] = template.intel

--- a/src/dct/templates/Template.lua
+++ b/src/dct/templates/Template.lua
@@ -289,6 +289,10 @@ local function getkeys(objtype)
 			["name"]    = "desc",
 			["type"]    = "string",
 			["default"] = "default template description",
+		},{
+			["name"]		= "codename",
+			["type"]		=	"string",
+			["default"]	=	"default codename"
 		},
 	}
 

--- a/src/dct/templates/Template.lua
+++ b/src/dct/templates/Template.lua
@@ -290,9 +290,9 @@ local function getkeys(objtype)
 			["type"]    = "string",
 			["default"] = "default template description",
 		},{
-			["name"]		= "codename",
-			["type"]		=	"string",
-			["default"]	=	"default codename"
+			["name"]    = "codename",
+			["type"]    = "string",
+			["default"] = "default codename"
 		},
 	}
 


### PR DESCRIPTION
Added new key to template.lua to take a "codename" string. Added handling in assetBase.lua to check for a changed string of the same name, and if preset set template codename to that rather than the generated default. 