### PR TITLE
Fix scenery life check

### DIFF
--- a/src/dct/goals/DamageGoal.lua
+++ b/src/dct/goals/DamageGoal.lua
@@ -13,6 +13,15 @@ local function initial_scenery_life()
 	return 1
 end
 
+local function get_scenery_life(obj)
+	if SceneryObject.isExist(obj) then
+		return SceneryObject.getLife(obj)
+	end
+	-- Undamaged scenery objects don't "exist" yet in the MSE,
+	-- so we return a safe full health value
+	return initial_scenery_life()
+end
+
 local function getobject(objtype, name, init)
 	local switch = {
 		[enums.objtype.UNIT]   = Unit.getByName,
@@ -33,7 +42,7 @@ local function getobject(objtype, name, init)
 		[enums.objtype.UNIT]   = Unit.getLife,
 		[enums.objtype.STATIC] = StaticObject.getLife,
 		[enums.objtype.GROUP]  = Group.getSize,
-		[enums.objtype.SCENERY]= SceneryObject.getLife,
+		[enums.objtype.SCENERY]= get_scenery_life,
 	}
 
 	local obj = nil


### PR DESCRIPTION
The periodic goal check in StaticAsset was trying to call SceneryObject.getLife on undamaged assets, which causes a "Scenery object doesn't exist" error, which previously handled at init time by stubbing out the initial health function, but raised its head again after the last patch. SceneryObject.isExist should cover the check until the object is damaged and destroyed, and hopefully things will be sane again.

Note: tested by destryoing a single-segment bridge object with an AGM-65L (destroyed in a single hit) near Aleppo in the Syria map. Do we know of any objects that return false for SceneryObject.isExist the moment they're destroyed?