### PR TITLE
theater: version state files

### DIFF
--- a/src/dct/Theater.lua
+++ b/src/dct/Theater.lua
@@ -23,6 +23,8 @@ local Command     = require("dct.Command")
 local Logger      = dct.Logger.getByName("Theater")
 local settings    = _G.dct.settings.server
 
+local STATE_VERSION = "1"
+
 local function isPlayerGroup(grp, _, _)
 	local slotcnt = 0
 	for _, unit in ipairs(grp.units) do
@@ -49,6 +51,11 @@ local function isStateValid(state)
 
 	if state.complete == true then
 		Logger:info("isStateValid(); theater goals were completed")
+		return false
+	end
+
+	if state.version ~= STATE_VERSION then
+		Logger:warn("isStateValid(); invalid state version")
 		return false
 	end
 
@@ -277,6 +284,7 @@ function Theater:export(_)
 	end
 
 	local exporttbl = {
+		["version"]  = STATE_VERSION,
 		["complete"] = self:getTickets():isComplete(),
 		["date"]     = os.date("*t", dctutils.zulutime(timer.getAbsTime())),
 		["theater"]  = env.mission.theatre,


### PR DESCRIPTION
Add a version to the state file. That way if we update the code that
breaks older state files we can just change this version and old
state files will automatically be ignored.