### PR TITLE
template: route names do not always exist

### DIFF
--- a/src/dct/settings/theater.lua
+++ b/src/dct/settings/theater.lua
@@ -139,11 +139,11 @@ local function theatercfgs(config)
 			["cfgtblname"] = "restrictedweapons",
 			["validate"] = validate_weapon_restrictions,
 			["default"] = {
-				["RN-24"] = {
+				["weapons.bombs.RN-24"] = {
 					["cost"]     = enum.WPNINFCOST,
 					["category"] = enum.weaponCategory.AG,
 				},
-				["RN-28"] = {
+				["weapons.bombs.RN-28"] = {
 					["cost"]     = enum.WPNINFCOST,
 					["category"] = enum.weaponCategory.AG,
 				},

--- a/src/dct/systems/loadouts.lua
+++ b/src/dct/systems/loadouts.lua
@@ -25,7 +25,7 @@ local function totalPayload(grp, limits)
 
 	-- tally restricted weapon cost
 	for _, wpn in ipairs(payload or {}) do
-		local wpnname = wpn.desc.displayName
+		local wpnname = wpn.desc.typeName
 		local wpncnt  = wpn.count
 		local restricted = restrictedWeapons[wpnname]
 

--- a/src/dct/templates/STM.lua
+++ b/src/dct/templates/STM.lua
@@ -125,8 +125,9 @@ end
 function STM.transform(stmdata, file)
 	local template   = {}
 	local lookupname =  function(name)
-		assert(name and type(name) == "string",
-			"value error: name must be provided and a string")
+		if name == nil then
+			return nil
+		end
 		local newname = name
 		local namelist = stmdata.localization.DEFAULT
 		if namelist[name] ~= nil then


### PR DESCRIPTION
DCS changed how routes were stored in stm files. Now if a route does not
have a name there is no name entry in the route entry. So we need to
allow for receiving a nil name.