### PR TITLE
loadouts: reference weapon type name

### DIFF
--- a/src/dct/settings/theater.lua
+++ b/src/dct/settings/theater.lua
@@ -139,11 +139,11 @@ local function theatercfgs(config)
 			["cfgtblname"] = "restrictedweapons",
 			["validate"] = validate_weapon_restrictions,
 			["default"] = {
-				["RN-24"] = {
+				["weapons.bombs.RN-24"] = {
 					["cost"]     = enum.WPNINFCOST,
 					["category"] = enum.weaponCategory.AG,
 				},
-				["RN-28"] = {
+				["weapons.bombs.RN-28"] = {
 					["cost"]     = enum.WPNINFCOST,
 					["category"] = enum.weaponCategory.AG,
 				},

--- a/src/dct/systems/loadouts.lua
+++ b/src/dct/systems/loadouts.lua
@@ -25,7 +25,7 @@ local function totalPayload(grp, limits)
 
 	-- tally restricted weapon cost
 	for _, wpn in ipairs(payload or {}) do
-		local wpnname = wpn.desc.displayName
+		local wpnname = wpn.desc.typeName
 		local wpncnt  = wpn.count
 		local restricted = restrictedWeapons[wpnname]
 


### PR DESCRIPTION
For loadout restrictions the weapon type name (typeName) should be used
instead of the display name as the display name can change depending on
internationalization and for other reasons. The type name should be the
fixed name that never changes.