### PR TITLE
theater: fixup land/takeoff events

### DIFF
--- a/hooks/dct-hook.lua
+++ b/hooks/dct-hook.lua
@@ -77,7 +77,7 @@ if not ok then
 end
 
 local dctenum
-ok, dctenum = pcall(require, "dct.enum")
+ok, dctenum = pcall(require, "dct.libs.kickinfo")
 if not ok then
 	log.write(facility, log.ERROR,
 		string.format("unable to require dct.enum: %s", dctenum))

--- a/src/dct/assets/Airbase.lua
+++ b/src/dct/assets/Airbase.lua
@@ -206,6 +206,21 @@ local function associate_slots(ab)
 		return false
 	end
 	local assetmgr = dct.Theater.singleton():getAssetMgr()
+
+	-- Associate player slots that cannot be autodetected by using
+	-- a list provided by the campaign designer. First look up the
+	-- template defining the airbase so that slots can be updated
+	-- without resetting the campaign state.
+	-- TODO: temp solution until a region manager is created
+	local region = dct.Theater.singleton().regions[ab.rgnname]
+	local tpl = region:getTemplateByName(ab.tplname)
+	for _, name in ipairs(tpl.players) do
+		local asset = assetmgr:getAsset(name)
+		if asset and asset.airbase == nil then
+			asset.airbase = ab.name
+		end
+	end
+
 	for name, _ in pairs(assetmgr:filterAssets(filter)) do
 		local asset = assetmgr:getAsset(name)
 		if asset then

--- a/src/dct/assets/AssetManager.lua
+++ b/src/dct/assets/AssetManager.lua
@@ -220,7 +220,8 @@ function AssetManager:doOneObject(obj, event)
 	end
 
 	local name = tostring(obj:getName())
-	if obj:getCategory() == Object.Category.UNIT then
+	if obj.className_ ~= "Airbase" and
+	   obj:getCategory() == Object.Category.UNIT then
 		name = obj:getGroup():getName()
 	end
 

--- a/src/dct/assets/StaticAsset.lua
+++ b/src/dct/assets/StaticAsset.lua
@@ -50,6 +50,7 @@ function StaticAsset.assettypes()
 		enum.assetType.CHECKPOINT,
 		enum.assetType.FACTORY,
 		enum.assetType.FOB,
+		enum.assetType.LOGISTICS,
 	}
 end
 

--- a/src/dct/enum.lua
+++ b/src/dct/enum.lua
@@ -102,6 +102,7 @@ enum.assetClass = {
 		[enum.assetType.SPECIALFORCES] = true,
 		[enum.assetType.FOB]           = true,
 		[enum.assetType.AIRSPACE]      = true,
+		[enum.assetType.LOGISTICS]     = true,
 	},
 	-- strategic list is used in calculating ownership of a region
 	-- among other things

--- a/src/dct/enum.lua
+++ b/src/dct/enum.lua
@@ -1,7 +1,7 @@
 --[[
 -- SPDX-License-Identifier: LGPL-3.0
 --
--- Provides functions for handling templates.
+-- Define some basic global enumerations for DCT.
 --]]
 
 local enum = {}
@@ -221,32 +221,6 @@ enum.event = {
 		--]]
 }
 
-enum.kickCode = {
-	["NOKICK"]  = 0,
-	["UNKNOWN"] = 1,
-	["SETUP"]   = 2,
-	["EMPTY"]   = 3,
-	["DEAD"]    = 4,
-	["LOADOUT"] = 5,
-	["MISSION"] = 6,
-}
-
-enum.kickReason = {
-	[enum.kickCode.NOKICK] =
-		"no kick requested, please report a. bug",
-	[enum.kickCode.UNKNOWN] =
-		"unknown reason, please report a bug.",
-	[enum.kickCode.SETUP] =
-		"slots being setup, please wait 1 minute.",
-	[enum.kickCode.EMPTY] =
-		"slot empty, please report a bug",
-	[enum.kickCode.DEAD] =
-		"you died, re-slot to continue.",
-	[enum.kickCode.LOADOUT] =
-		"payload violation, you attempted to takeoff with restricted "..
-		"weapons. Check the loadout limits.",
-	[enum.kickCode.MISSION] =
-		"no mission assigned. Must have a mission assigned.",
-}
+enum.kickCode = require("dct.libs.kickinfo").kickCode
 
 return enum

--- a/src/dct/libs/kickinfo.lua
+++ b/src/dct/libs/kickinfo.lua
@@ -1,0 +1,37 @@
+--[[
+-- SPDX-License-Identifier: LGPL-3.0
+--
+-- Defines kick codes and associated error messages.
+--]]
+
+local enum = {}
+
+enum.kickCode = {
+	["NOKICK"]  = 0,
+	["UNKNOWN"] = 1,
+	["SETUP"]   = 2,
+	["EMPTY"]   = 3,
+	["DEAD"]    = 4,
+	["LOADOUT"] = 5,
+	["MISSION"] = 6,
+}
+
+enum.kickReason = {
+	[enum.kickCode.NOKICK] =
+		"no kick requested, please report a. bug",
+	[enum.kickCode.UNKNOWN] =
+		"unknown reason, please report a bug.",
+	[enum.kickCode.SETUP] =
+		"slots being setup, please wait 1 minute.",
+	[enum.kickCode.EMPTY] =
+		"slot empty, please report a bug",
+	[enum.kickCode.DEAD] =
+		"you died, re-slot to continue.",
+	[enum.kickCode.LOADOUT] =
+		"payload violation, you attempted to takeoff with restricted "..
+		"weapons. Check the loadout limits.",
+	[enum.kickCode.MISSION] =
+		"no mission assigned. Must have a mission assigned.",
+}
+
+return enum

--- a/src/dct/templates/Template.lua
+++ b/src/dct/templates/Template.lua
@@ -351,6 +351,15 @@ local function getkeys(objtype)
 			["default"] = dct.settings.payloadlimits,
 		})
 	end
+
+	if objtype == enum.assetType.SQUADRONPLAYER or
+	   objtype == enum.assetType.AIRBASE then
+		table.insert(keys, {
+			["name"]  = "players",
+			["type"]  = "table",
+			["default"] = {},
+		})
+   end
 	return keys
 end
 

--- a/src/dcttestlibs/dcsstubs.lua
+++ b/src/dcttestlibs/dcsstubs.lua
@@ -1003,6 +1003,14 @@ function Group:__init(unitcnt, objdata)
 	self.inAir = nil
 end
 
+Group.Category = {
+	AIRPLANE   = 0,
+	HELICOPTER = 1,
+	GROUND     = 2,
+	SHIP       = 3,
+	TRAIN      = 4,
+}
+
 function Group.getByName(name)
 	return objects[Object.Category.GROUP][name]
 end


### PR DESCRIPTION
Some FARPs do not emmit takeoff or landing events. This attempts to
detect if a FARP is within a defined radius and amends the event object
to include the airbase.