### PR TITLE
hooks: fix require of enum

### DIFF
--- a/hooks/dct-hook.lua
+++ b/hooks/dct-hook.lua
@@ -77,7 +77,7 @@ if not ok then
 end
 
 local dctenum
-ok, dctenum = pcall(require, "dct.enum")
+ok, dctenum = pcall(require, "dct.libs.kickinfo")
 if not ok then
 	log.write(facility, log.ERROR,
 		string.format("unable to require dct.enum: %s", dctenum))

--- a/src/dct/enum.lua
+++ b/src/dct/enum.lua
@@ -1,7 +1,7 @@
 --[[
 -- SPDX-License-Identifier: LGPL-3.0
 --
--- Provides functions for handling templates.
+-- Define some basic global enumerations for DCT.
 --]]
 
 local enum = {}
@@ -221,32 +221,6 @@ enum.event = {
 		--]]
 }
 
-enum.kickCode = {
-	["NOKICK"]  = 0,
-	["UNKNOWN"] = 1,
-	["SETUP"]   = 2,
-	["EMPTY"]   = 3,
-	["DEAD"]    = 4,
-	["LOADOUT"] = 5,
-	["MISSION"] = 6,
-}
-
-enum.kickReason = {
-	[enum.kickCode.NOKICK] =
-		"no kick requested, please report a. bug",
-	[enum.kickCode.UNKNOWN] =
-		"unknown reason, please report a bug.",
-	[enum.kickCode.SETUP] =
-		"slots being setup, please wait 1 minute.",
-	[enum.kickCode.EMPTY] =
-		"slot empty, please report a bug",
-	[enum.kickCode.DEAD] =
-		"you died, re-slot to continue.",
-	[enum.kickCode.LOADOUT] =
-		"payload violation, you attempted to takeoff with restricted "..
-		"weapons. Check the loadout limits.",
-	[enum.kickCode.MISSION] =
-		"no mission assigned. Must have a mission assigned.",
-}
+enum.kickCode = require("dct.libs.kickinfo").kickCode
 
 return enum

--- a/src/dct/libs/kickinfo.lua
+++ b/src/dct/libs/kickinfo.lua
@@ -1,0 +1,37 @@
+--[[
+-- SPDX-License-Identifier: LGPL-3.0
+--
+-- Defines kick codes and associated error messages.
+--]]
+
+local enum = {}
+
+enum.kickCode = {
+	["NOKICK"]  = 0,
+	["UNKNOWN"] = 1,
+	["SETUP"]   = 2,
+	["EMPTY"]   = 3,
+	["DEAD"]    = 4,
+	["LOADOUT"] = 5,
+	["MISSION"] = 6,
+}
+
+enum.kickReason = {
+	[enum.kickCode.NOKICK] =
+		"no kick requested, please report a. bug",
+	[enum.kickCode.UNKNOWN] =
+		"unknown reason, please report a bug.",
+	[enum.kickCode.SETUP] =
+		"slots being setup, please wait 1 minute.",
+	[enum.kickCode.EMPTY] =
+		"slot empty, please report a bug",
+	[enum.kickCode.DEAD] =
+		"you died, re-slot to continue.",
+	[enum.kickCode.LOADOUT] =
+		"payload violation, you attempted to takeoff with restricted "..
+		"weapons. Check the loadout limits.",
+	[enum.kickCode.MISSION] =
+		"no mission assigned. Must have a mission assigned.",
+}
+
+return enum


### PR DESCRIPTION
The enum.lua file has grown and references symbols not available in the
hooks environment. Break out from the enum.lua the specific additions to
the enum.lua that are also needed in hooks and reference this specific
file in the hooks script.

Closes: #189