### PR TITLE
groupmenu: fix crash caused under specific circumstances

### DIFF
--- a/src/dct/Theater.lua
+++ b/src/dct/Theater.lua
@@ -110,6 +110,8 @@ function Theater:__init()
 		self.delayedInit, self))
 	self:queueCommand(100, Command(self.__clsname..".export",
 		self.export, self))
+	self.singleton = nil
+	self.playerRequest = nil
 end
 
 function Theater.singleton()
@@ -380,7 +382,8 @@ function Theater:getTickets()
 	return self:getSystem("dct.systems.tickets")
 end
 
-function Theater:playerRequest(data)
+function Theater.playerRequest(data)
+	local self = Theater.singleton()
 	if data == nil then
 		Logger:error("playerRequest(); value error: data must be "..
 			"provided; "..debug.traceback())

--- a/src/dct/systems/loadouts.lua
+++ b/src/dct/systems/loadouts.lua
@@ -62,11 +62,11 @@ function loadout.check(player)
 		player.payloadlimits)
 end
 
-function loadout.addmenu(asset, menu, handler, context)
+function loadout.addmenu(asset, menu, handler)
 	local gid  = asset.groupId
 	local name = asset.name
-	missionCommands.addCommandForGroup(gid,
-		"Check Payload", menu, handler, context, {
+	return missionCommands.addCommandForGroup(gid,
+		"Check Payload", menu, handler, {
 			["name"]   = name,
 			["type"]   = enum.uiRequestType.CHECKPAYLOAD,
 		})

--- a/src/dct/ui/groupmenu.lua
+++ b/src/dct/ui/groupmenu.lua
@@ -21,12 +21,12 @@
 local enum    = require("dct.enum")
 local Logger  = dct.Logger.getByName("UI")
 local loadout = require("dct.systems.loadouts")
+local Theater = require("dct.Theater")
 local addmenu = missionCommands.addSubMenuForGroup
 local addcmd  = missionCommands.addCommandForGroup
 
 local menus = {}
 function menus.createMenu(asset)
-	local theater = require("dct.Theater").singleton()
 	local gid  = asset.groupId
 	local name = asset.name
 
@@ -43,14 +43,14 @@ function menus.createMenu(asset)
 	for k, v in pairs({
 		["DISPLAY"] = enum.uiRequestType.SCRATCHPADGET,
 		["SET"] = enum.uiRequestType.SCRATCHPADSET}) do
-		addcmd(gid, k, padmenu, theater.playerRequest, theater,
+		addcmd(gid, k, padmenu, Theater.playerRequest,
 			{
 				["name"]   = name,
 				["type"]   = v,
 			})
 	end
 
-	addcmd(gid, "Theater Update", nil, theater.playerRequest, theater,
+	addcmd(gid, "Theater Update", nil, Theater.playerRequest,
 		{
 			["name"]   = name,
 			["type"]   = enum.uiRequestType.THEATERSTATUS,
@@ -59,7 +59,7 @@ function menus.createMenu(asset)
 	local msnmenu = addmenu(gid, "Mission", nil)
 	local rqstmenu = addmenu(gid, "Request", msnmenu)
 	for k, v in pairs(asset.ato) do
-		addcmd(gid, k, rqstmenu, theater.playerRequest, theater,
+		addcmd(gid, k, rqstmenu, Theater.playerRequest,
 			{
 				["name"]   = name,
 				["type"]   = enum.uiRequestType.MISSIONREQUEST,
@@ -67,35 +67,35 @@ function menus.createMenu(asset)
 			})
 	end
 
-	addcmd(gid, "Join", msnmenu, theater.playerRequest, theater,
+	addcmd(gid, "Join", msnmenu, Theater.playerRequest,
 		{
 			["name"]   = name,
 			["type"]   = enum.uiRequestType.MISSIONJOIN,
 		})
 
-	addcmd(gid, "Briefing", msnmenu, theater.playerRequest, theater,
+	addcmd(gid, "Briefing", msnmenu, Theater.playerRequest,
 		{
 			["name"]   = name,
 			["type"]   = enum.uiRequestType.MISSIONBRIEF,
 		})
-	addcmd(gid, "Status", msnmenu, theater.playerRequest, theater,
+	addcmd(gid, "Status", msnmenu, Theater.playerRequest,
 		{
 			["name"]   = name,
 			["type"]   = enum.uiRequestType.MISSIONSTATUS,
 		})
-	addcmd(gid, "Abort", msnmenu, theater.playerRequest, theater,
+	addcmd(gid, "Abort", msnmenu, Theater.playerRequest,
 		{
 			["name"]   = name,
 			["type"]   = enum.uiRequestType.MISSIONABORT,
 			["value"]  = enum.missionAbortType.ABORT,
 		})
-	addcmd(gid, "Rolex +30", msnmenu, theater.playerRequest, theater,
+	addcmd(gid, "Rolex +30", msnmenu, Theater.playerRequest,
 		{
 			["name"]   = name,
 			["type"]   = enum.uiRequestType.MISSIONROLEX,
 			["value"]  = 30*60,  -- seconds
 		})
-	loadout.addmenu(asset, nil, theater.playerRequest, theater)
+	loadout.addmenu(asset, nil, Theater.playerRequest)
 end
 
 return menus

--- a/tests/test-ui-cmds2.lua
+++ b/tests/test-ui-cmds2.lua
@@ -61,7 +61,7 @@ local function main()
 	for _, v in ipairs(testcmds) do
 		trigger.action.setassert(v.assert)
 		trigger.action.setmsgbuffer(v.expected)
-		theater:playerRequest(v.data)
+		dct.Theater.playerRequest(v.data)
 	end
 	return 0
 end


### PR DESCRIPTION
missionCommands.addMenu accepts multiple user arguments to the handler
function, however, it seems that behavior is not documented, and the
extra parameters can cause memory corruption under certain circumstances
when running queued commands on units that have been removed by the slot
kicker. By reducing the user arguments to one, the functions behave
correctly and DCS doesn't crash anymore when calling them. The
theater object used to be passed in the commands, but now it is injected
directly into the playerRequest method via the singleton call (as it was
done in groupmenu.lua before).
