### PR TITLE
Make tpldata in .dct default to an empty table

### DIFF
--- a/data/mission/theater/region1/test/bldgTest2.dct
+++ b/data/mission/theater/region1/test/bldgTest2.dct
@@ -1,0 +1,19 @@
+metadata = {
+	["rank"]     = 2,
+	["objtype"]  = "factory",
+	["intel"]	 = 1,
+	["name"]     = "bldgTest2",
+	["coalition"]= 1, -- redfor
+	["buildings"]= {
+		{
+			["name"] = "building 1",
+			["goal"] = "primary destroyed",
+			["id"]   = 1,
+		}, {
+			["name"] = "building 2",
+			["goal"] = "primary destroyed",
+			["id"]   = 2,
+		},
+	},
+	["alwaysSpawn"] = false,
+}

--- a/data/mission/theater/region1/test/bldgTest2.dct
+++ b/data/mission/theater/region1/test/bldgTest2.dct
@@ -1,10 +1,10 @@
 metadata = {
-	["rank"]     = 2,
-	["objtype"]  = "factory",
-	["intel"]	 = 1,
-	["name"]     = "bldgTest2",
-	["coalition"]= 1, -- redfor
-	["buildings"]= {
+	["rank"]      = 2,
+	["objtype"]   = "factory",
+	["intel"]	  = 1,
+	["name"]      = "bldgTest2",
+	["coalition"] = 1, -- redfor
+	["buildings"] = {
 		{
 			["name"] = "building 1",
 			["goal"] = "primary destroyed",

--- a/src/dct/templates/Template.lua
+++ b/src/dct/templates/Template.lua
@@ -303,6 +303,7 @@ local function getkeys(objtype)
 		table.insert(keys, {
 			["name"]  = "tpldata",
 			["type"]  = "table",
+			["default"] = {},
 			["check"] = checktpldata,})
 		table.insert(keys, {
 			["name"]    = "buildings",

--- a/src/dct/templates/Template.lua
+++ b/src/dct/templates/Template.lua
@@ -315,7 +315,7 @@ local function getkeys(objtype)
 		table.insert(keys, {
 			["name"]  = "tpldata",
 			["type"]  = "table",
-			["check"] = checktpldata,})	
+			["check"] = checktpldata,})
 	end
 
 	if objtype == enum.assetType.AIRSPACE then

--- a/src/dct/templates/Template.lua
+++ b/src/dct/templates/Template.lua
@@ -96,6 +96,10 @@ local function overrideUnitOptions(unit, key, tpl, basename)
 end
 
 local function overrideGroupOptions(grp, idx, tpl)
+	if grp.category == enum.UNIT_CAT_SCENERY then
+		return
+	end
+
 	local opts = {
 		visible        = true,
 		uncontrollable = true,
@@ -147,6 +151,9 @@ local function checkbldgdata(keydata, tpl)
 		local sceneryobject = { id_ = tonumber(bldgdata.data.name), }
 		utils.mergetables(bldgdata.data,
 			vector.Vector2D(Object.getPoint(sceneryobject)):raw())
+		if tpl.tpldata == nil then
+			tpl.tpldata = {}
+		end
 		table.insert(tpl.tpldata, bldgdata)
 		if bldgdata.data.dct_deathgoal ~= nil then
 			tpl.hasDeathGoals = true
@@ -301,15 +308,14 @@ local function getkeys(objtype)
 
 	if notpldata[objtype] == nil then
 		table.insert(keys, {
-			["name"]  = "tpldata",
-			["type"]  = "table",
-			["default"] = {},
-			["check"] = checktpldata,})
-		table.insert(keys, {
 			["name"]    = "buildings",
 			["type"]    = "table",
 			["default"] = {},
 			["check"] = checkbldgdata,})
+		table.insert(keys, {
+			["name"]  = "tpldata",
+			["type"]  = "table",
+			["check"] = checktpldata,})	
 	end
 
 	if objtype == enum.assetType.AIRSPACE then


### PR DESCRIPTION
This makes so that building-only templates with no accompanying .stm do not need `tpldata = {}` to be manually defined to pass validation, by applying it as a default value on validation.