### PR TITLE
scratchpad: fix latent bug after system rework

### DIFF
--- a/src/dct/ui/cmds.lua
+++ b/src/dct/ui/cmds.lua
@@ -78,7 +78,7 @@ function ScratchPadSet:_execute(_, _)
 	local pos   = Group.getByName(self.asset.name):getUnit(1):getPoint()
 	local title = "SCRATCHPAD "..tostring(self.asset.groupId)
 
-	self.theater.scratchpad[mrkid] = self.asset.name
+	self.theater:getSystem("dct.ui.scratchpad"):set(mrkid, self.asset.name)
 	trigger.action.markToGroup(mrkid, "edit me", pos,
 		self.asset.groupId, false)
 	local msg = "Look on F10 MAP for user mark with title: "..


### PR DESCRIPTION
This change was missed during the initial refactor of how systems
register with the theater. This will restor functionality of the
scratchpad.

Fixes: 02827edee955 ("systems: rework how systems register with theater")