### PR TITLE
systems: fix error in weaponstracking

### DIFF
--- a/src/dct/systems/weaponstracking.lua
+++ b/src/dct/systems/weaponstracking.lua
@@ -26,7 +26,8 @@ local function isWpnValid(event)
 	   return false
 	end
 
-	if wpndesc.warhead.type ~= Weapon.WarheadType.HE then
+	if wpndesc.warhead == nil or
+	   wpndesc.warhead.type ~= Weapon.WarheadType.HE then
 		return false
 	end
 	return true


### PR DESCRIPTION
It seems some weapons do not have warhead tables and results in the
following error:

[string "C:\Users\hoggit\Saved Games\DCS.openbeta_server\Mods\tech\DCT\lua\dct\systems\weaponstracking.lua"]:29: attempt to index field 'warhead' (a nil value)

The solution is to just ignore those weapon entries that are missing
warhead tables.