### PR TITLE
AssetManager: prevent removal of Player assets

### DIFF
--- a/src/dct/assets/AssetManager.lua
+++ b/src/dct/assets/AssetManager.lua
@@ -72,7 +72,9 @@ function AssetManager:factory(assettype)
 end
 
 function AssetManager:remove(asset)
-	assert(asset ~= nil, "value error: asset object must be provided")
+	if asset == nil then
+		return
+	end
 
 	asset:removeObserver(self)
 	self._assetset[asset.name] = nil
@@ -200,13 +202,10 @@ local function handleDead(self, event)
 	self._object2asset[tostring(event.initiator:getName())] = nil
 end
 
-local function handleAssetDeath(self, event)
+local function handleAssetDeath(_ --[[self]], event)
 	local asset = event.initiator
 	dct.Theater.singleton():getTickets():loss(asset.owner,
 		asset.cost, false)
-	if asset.type ~= enum.assetType.PLAYERGROUP then
-		self:remove(asset)
-	end
 end
 
 local handlers = {

--- a/src/dct/assets/Player.lua
+++ b/src/dct/assets/Player.lua
@@ -338,6 +338,12 @@ function Player:_setup()
 	self.state:enter(self)
 end
 
+-- Player assets cannot die, prevent them from ever being cleaned up
+-- by the AssetManager
+function Player:isDead()
+	return false
+end
+
 function Player:inAir()
 	self.inair = self.state.inair or false
 	return self.inair


### PR DESCRIPTION
Player assets are special and the code assumes they are never deleted.
They also utilize setting the dead flag to emit a DCT asset dead event
so that ticket accounting is done properly. This unfortunately makes
Player assets look dead to the rest of the system and so we need to
teach the Player assets to appear to the rest of the system that they
are not dead while keeping the nice inherited functionality of sending
a dead event.

Fixes: 07f24fd41857 ("asset manager: check if assets are dead")