### PR TITLE
systems: fix calling of postinit method

### DIFF
--- a/src/dct/Theater.lua
+++ b/src/dct/Theater.lua
@@ -145,8 +145,8 @@ end
 
 function Theater:postinitSystems()
 	for _, sys in pairs(self._systems) do
-		if type(sys.initpost) == "function" then
-			sys:initpost(self)
+		if type(sys.postinit) == "function" then
+			sys:postinit(self)
 		end
 	end
 end


### PR DESCRIPTION
The original commit incorrectly attempting to call initpost as the
method to be called after initialization was complete. This had the
effect of disabling scenery descruction tracking in DCT.

Fixes: adcbe02a61b3 ("systems: while restoring state ignore scenery events")
(cherry picked from commit 8c02854689a0f661b22ca59562e8a768fa6973b8)
Signed-off-by: Jonathan Toppins <jtoppins@users.noreply.github.com>