### PR TITLE
ui: show breakdown of loaded weapons in payload check

### DIFF
--- a/data/DCT/theaters/Caucasus_dctdemo/settings/restrictedweapons.cfg
+++ b/data/DCT/theaters/Caucasus_dctdemo/settings/restrictedweapons.cfg
@@ -3,6 +3,10 @@ restrictedweapons = {
 		["cost"] = INFCOST,
 		["category"] = "aa",
 	},
+	["AIM_120"] = {
+		["cost"] = 5,
+		["category"] = "aa",
+	},
 	["GBU_12"] = {
 		["cost"] = 5,
 		["category"] = "ag",

--- a/src/dct/systems/loadouts.lua
+++ b/src/dct/systems/loadouts.lua
@@ -10,8 +10,20 @@ local enum     = require("dct.enum")
 local dctutils = require("dct.utils")
 local settings = _G.dct.settings
 
--- returns totals for all weapon types, returns nil if the group
--- does not exist
+local isAAMissile = {
+	[Weapon.MissileCategory.AAM] = true,
+	[Weapon.MissileCategory.SAM] = true,
+}
+
+local function defaultCategory(weapon)
+	if isAAMissile[weapon.desc.missileCategory] then
+		return enum.weaponCategory.AA
+	elseif weapon.desc.category ~= Weapon.Category.SHELL then
+		return enum.weaponCategory.AG
+	end
+end
+
+-- returns totals for all weapon types, or nil if the group does not exist
 local function totalPayload(grp, limits)
 	local unit = grp:getUnit(1)
 	local restrictedWeapons = settings.restrictedweapons
@@ -20,20 +32,28 @@ local function totalPayload(grp, limits)
 	for _, v in pairs(enum.weaponCategory) do
 		total[v] = {
 			["current"] = 0,
-			["max"]     = limits[v],
+			["max"]     = limits[v] or 0,
+			["payload"] = {}
 		}
 	end
 
-	-- tally restricted weapon cost
+	-- tally weapon costs
 	for _, wpn in ipairs(payload or {}) do
 		local wpnname = dctutils.trimTypeName(wpn.desc.typeName)
 		local wpncnt  = wpn.count
-		local restricted = restrictedWeapons[wpnname]
+		local restriction = restrictedWeapons[wpnname] or {}
+		local category = restriction.category or defaultCategory(wpn)
+		local cost = restriction.cost or 0
 
-		if restricted then
-			total[restricted.category].current =
-				total[restricted.category].current +
-				(wpncnt * restricted.cost)
+		if category ~= nil then
+			total[category].current =
+				total[category].current + (wpncnt * cost)
+
+			table.insert(total[category].payload, {
+				["name"] = wpn.desc.displayName,
+				["count"] = wpncnt,
+				["cost"] = cost,
+			})
 		end
 	end
 	return total

--- a/src/dct/utils.lua
+++ b/src/dct/utils.lua
@@ -231,7 +231,9 @@ function utils.fmtposition(position, precision, fmt)
 end
 
 function utils.trimTypeName(typename)
-	return string.match(typename, "[^.]-$")
+	if typename ~= nil then
+		return string.match(typename, "[^.]-$")
+	end
 end
 
 utils.buildevent = {}

--- a/src/dcttestlibs/dcsstubs.lua
+++ b/src/dcttestlibs/dcsstubs.lua
@@ -754,6 +754,7 @@ function Unit:__init(objdata, group, pname)
 	Coalition.__init(self, objdata)
 	self.clife = self.desc.life
 	self.group = group
+	self.ammo = objdata.ammo
 	if group ~= nil then
 		group:_addUnit(self)
 	end
@@ -797,6 +798,10 @@ end
 
 function Unit:getCallsign()
 	return "foo"
+end
+
+function Unit:getAmmo()
+	return self.ammo
 end
 _G.Unit = Unit
 

--- a/tests/test-ui-cmds.lua
+++ b/tests/test-ui-cmds.lua
@@ -132,6 +132,74 @@ local testcmds = {
 		},
 		["assert"]     = true,
 		["expected"]   = "Mission 5720 aborted",
+	}, {
+		-- Allowed payload
+		["data"] = {
+			["name"]   = grp:getName(),
+			["type"]   = enum.uiRequestType.CHECKPAYLOAD,
+		},
+		["ammo"] = {
+			{
+				["desc"] = {
+					["displayName"] = "Cannon Shells",
+					["category"] = Weapon.Category.SHELL,
+				},
+				["count"] = 600,
+			}, {
+				["desc"] = {
+					["displayName"] = "AIM-9M",
+					["typeName"] = "AIM_9",
+					["category"] = Weapon.Category.MISSILE,
+					["missileCategory"] = Weapon.MissileCategory.AAM,
+				},
+				["count"] = 2,
+			}, {
+				["desc"] = {
+					["displayName"] = "AIM-120B",
+					["typeName"] = "AIM_120",
+					["category"] = Weapon.Category.MISSILE,
+					["missileCategory"] = Weapon.MissileCategory.AAM,
+				},
+				["count"] = 4,
+			}
+		},
+		["assert"]     = true,
+		["expected"]   = "Valid loadout, you may depart. Good luck!\n\n"..
+			"== Loadout Summary:\n"..
+			"  AA cost: 20 / 20\n"..
+			"  AG cost: 0 / 60\n"..
+			"\n"..
+			"== AA Weapons:\n"..
+			"  AIM-9M\n"..
+			"    ↳ 2 × unrestricted (0 pts)\n"..
+			"  AIM-120B\n"..
+			"    ↳ 4 × 5 pts = 20 pts",
+	}, {
+		-- Over limit with forbidden weapon
+		["data"] = {
+			["name"]   = grp:getName(),
+			["type"]   = enum.uiRequestType.CHECKPAYLOAD,
+		},
+		["ammo"] = {
+			{
+				["desc"] = {
+					["displayName"] = "RN-28",
+					["typeName"] = "RN-28",
+					["category"] = Weapon.Category.BOMB,
+				},
+				["count"] = 1,
+			}
+		},
+		["assert"]     = true,
+		["expected"]   = "You are over budget! Re-arm before departing, or "..
+			"you will be punished!\n\n"..
+			"== Loadout Summary:\n"..
+			"  AA cost: 0 / 20\n"..
+			"  AG cost: -- / 60\n"..
+			"\n"..
+			"== AG Weapons:\n"..
+			"  RN-28\n"..
+			"    ↳ Weapon cannot be used in this theater [!]",
 	},
 }
 
@@ -147,6 +215,9 @@ local function main()
 	for _, v in ipairs(testcmds) do
 		if v.modelTime ~= nil then
 			timer.stub_setTime(v.modelTime)
+		end
+		if v.ammo ~= nil then
+			unit1.ammo = v.ammo
 		end
 		trigger.action.setassert(v.assert)
 		trigger.action.setmsgbuffer(v.expected)


### PR DESCRIPTION
Closes #173 

This PR has been tested in-game and includes the following changes:

* Structured breakdown of loaded weapons and their point costs displayed in the loadout check message
* More neutral language ("you will be punished" vs "you will be kicked")
* Accompanying UI tests

Examples:
![loadout](https://user-images.githubusercontent.com/6194377/132265561-24ec00ad-ccae-4733-afc7-49a8ef6d7313.PNG)
![image](https://user-images.githubusercontent.com/6194377/132265568-28ea7eac-17d1-4235-bfcd-46184794e2bf.png)

Feedback welcome.