### PR TITLE
mission-init: extend environment check

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,6 +6,7 @@ max_line_length = 80
 max_cyclomatic_complexity = 10
 read_globals = {
 	-- common lua globals
+	"loadlib",
 	"lfs",
 	"md5",
 

--- a/mission/dct-mission-init.lua
+++ b/mission/dct-mission-init.lua
@@ -10,12 +10,14 @@
 --]]
 
 do
-	if not lfs or not io or not require then
+	if not lfs or not io or not os or not require or not loadlib then
 		local assertmsg = "DCT requires DCS mission scripting environment"..
 			" to be modified, the file needing to be changed can be found"..
 			" at $DCS_ROOT\\Scripts\\MissionScripting.lua. Comment out"..
-			" the removal of lfs and io and the setting of 'require' to"..
-			" nil."
+			" the removal of lfs, io, os, 'require' and 'loadlib'."..
+			" *WARNING:* Running an unsanitized environment can open the"..
+			" system up to unauthorized file-system writes, only run"..
+			" DCS missions which you trust."
 		assert(false, assertmsg)
 	end
 


### PR DESCRIPTION
Extend mission environment check to cover 'os' and 'loadlib'.

Closes: #213