### PR TITLE
damagegoal: refine scenery object handling

### DIFF
--- a/src/dct/assets/StaticAsset.lua
+++ b/src/dct/assets/StaticAsset.lua
@@ -274,8 +274,12 @@ function StaticAsset:_spawn()
 	end
 
 	AssetBase.spawn(self)
-	for _, goal in pairs(self._deathgoals) do
+
+	for name, goal in pairs(self._deathgoals) do
 		goal:onSpawn()
+		if goal:isComplete() then
+			self:_removeDeathGoal(name)
+		end
 	end
 end
 


### PR DESCRIPTION
- ED fixed a bug where undamaged objects were considered non-existant, so now we can (correctly) treat non-existant objects as dead
- We now remove completed goals when an asset is spawned, so if all of its parts are dead on spawn (for any reason), it will not be a valid target for a mission, and will be removed from the theater

These changes are aimed at fixing a softlock caused by scenery objects being destroyed before the theater is fully initialized (ie. by collateral damage from the building persistence system), where they will still be considered alive but not be able to be damaged in the world anymore (as dead objects will be considered non-existing and won't emit any new death events)