### PR TITLE
IFF code generation overhaul

### DIFF
--- a/src/dct/ai/Commander.lua
+++ b/src/dct/ai/Commander.lua
@@ -109,31 +109,6 @@ local invalidXpdrTbl = {
 	["7400"] = true,
 }
 
-local squawkMissionType = {
-	["SAR"]  = 0,
-	["SUPT"] = 1,
-	["A2A"]  = 2,
-	["SEAD"] = 3,
-	["SEA"]  = 4,
-	["A2G"]  = 5,
-}
-
-local function map_mission_type(msntype)
-	local sqwkcode
-	if msntype == enum.missionType.CAP then
-		sqwkcode = squawkMissionType.A2A
-	--elseif msntype == enum.missionType.SAR then
-	--	sqwkcode = squawkMissionType.SAR
-	--elseif msntype == enum.missionType.SUPPORT then
-	--	sqwkcode = squawkMissionType.SUPT
-	elseif msntype == enum.missionType.SEAD then
-		sqwkcode = squawkMissionType.SEAD
-	else
-		sqwkcode = squawkMissionType.A2G
-	end
-	return sqwkcode
-end
-
 --[[
 -- Generates a mission id as well as generating IFF codes for the
 -- mission.
@@ -146,7 +121,7 @@ end
 --]]
 function Commander:genMissionCodes(msntype)
 	local id
-	local m1 = map_mission_type(msntype)
+	local m1 = enum.squawkMissionType[msntype]
 	while true do
 		MISSION_ID = (MISSION_ID + 1) % 64
 		id = string.format("%01o%02o0", m1, MISSION_ID)

--- a/src/dct/ai/Commander.lua
+++ b/src/dct/ai/Commander.lua
@@ -129,7 +129,7 @@ function Commander:genMissionCodes(msntype)
 			break
 		end
 	end
-	local m1 = 8*digit1
+	local m1 = (8*digit1)+(enum.squawkMissionSubType[msntype] or 0)
 	local m3 = (512*digit1)+(MISSION_ID*8)
 	return { ["id"] = id, ["m1"] = m1, ["m3"] = m3, }
 end

--- a/src/dct/ai/Commander.lua
+++ b/src/dct/ai/Commander.lua
@@ -111,7 +111,7 @@ local invalidXpdrTbl = {
 
 --[[
 -- Generates a mission id as well as generating IFF codes for the
--- mission.
+-- mission (in octal).
 --
 -- Returns: a table with the following:
 --   * id (string): is the mission ID
@@ -121,16 +121,16 @@ local invalidXpdrTbl = {
 --]]
 function Commander:genMissionCodes(msntype)
 	local id
-	local m1 = enum.squawkMissionType[msntype]
+	local digit1 = enum.squawkMissionType[msntype]
 	while true do
 		MISSION_ID = (MISSION_ID + 1) % 64
-		id = string.format("%01o%02o0", m1, MISSION_ID)
-		if invalidXpdrTbl[id] == nil and
-			self:getMission(id) == nil then
+		id = string.format("%01o%02o0", digit1, MISSION_ID)
+		if invalidXpdrTbl[id] == nil and self:getMission(id) == nil then
 			break
 		end
 	end
-	local m3 = (512*m1)+(MISSION_ID*8)
+	local m1 = 8*digit1
+	local m3 = (512*digit1)+(MISSION_ID*8)
 	return { ["id"] = id, ["m1"] = m1, ["m3"] = m3, }
 end
 

--- a/src/dct/ai/Mission.lua
+++ b/src/dct/ai/Mission.lua
@@ -185,6 +185,8 @@ function Mission:__init(cmdr, missiontype, tgt, plan)
 	self:_setComplete(false)
 	self.state = PrepState()
 	self.state:enter(self)
+	self._assignedIds = {}
+	self._lastAssignedId = 0
 
 	-- compose the briefing at mission creation to represent
 	-- known intel the pilots were given before departing
@@ -223,6 +225,10 @@ function Mission:addAssigned(asset)
 		return
 	end
 	table.insert(self.assigned, asset.name)
+	if self._assignedIds[asset.name] == nil then
+		self._assignedIds[asset.name] = self._lastAssignedId
+		self._lastAssignedId = self._lastAssignedId + 1
+	end
 	Logger:debug("Mission %d: addAssigned(%s)", self.id, asset.name)
 	asset.missionid = self:getID()
 end
@@ -329,6 +335,16 @@ end
 function Mission:addTime(time)
 	self.state:timeextend(time)
 	return time
+end
+
+function Mission:getIFFCodes(asset)
+	local assignedId = 0
+	if asset ~= nil then
+		assignedId = (self._assignedIds[asset.name] or 0) % 8
+	end
+	local m1 = string.format("%o", self.iffcodes.m1)
+	local m3 = string.format("%o", self.iffcodes.m3 + assignedId)
+	return { ["m1"] = m1, ["m3"] = m3 }
 end
 
 function Mission:getDescription(fmt)

--- a/src/dct/enum.lua
+++ b/src/dct/enum.lua
@@ -93,6 +93,14 @@ enum.squawkMissionType = {
 	[enum.missionType.ARMEDRECON] = 5,
 }
 
+enum.squawkMissionSubType = {
+	[enum.missionType.STRIKE]     = 0,
+	[enum.missionType.OCA]        = 0,
+	[enum.missionType.BAI]        = 1,
+	[enum.missionType.ARMEDRECON] = 2,
+	[enum.missionType.CAS]        = 3,
+}
+
 enum.assetClass = {
 	["INITIALIZE"] = {
 		[enum.assetType.AMMODUMP]    = true,

--- a/src/dct/enum.lua
+++ b/src/dct/enum.lua
@@ -74,13 +74,23 @@ enum.assetTypePriority = {
 enum.missionInvalidID = 0
 
 enum.missionType = {
-	["CAS"]      = 1,
-	["CAP"]      = 2,
-	["STRIKE"]   = 3,
-	["SEAD"]     = 4,
-	["BAI"]      = 5,
-	["OCA"]      = 6,
+	["CAS"]        = 1,
+	["CAP"]        = 2,
+	["STRIKE"]     = 3,
+	["SEAD"]       = 4,
+	["BAI"]        = 5,
+	["OCA"]        = 6,
 	["ARMEDRECON"] = 7,
+}
+
+enum.squawkMissionType = {
+	[enum.missionType.CAP]        = 2,
+	[enum.missionType.SEAD]       = 3,
+	[enum.missionType.CAS]        = 5,
+	[enum.missionType.STRIKE]     = 5,
+	[enum.missionType.BAI]        = 5,
+	[enum.missionType.OCA]        = 5,
+	[enum.missionType.ARMEDRECON] = 5,
 }
 
 enum.assetClass = {
@@ -237,5 +247,10 @@ enum.event = {
 }
 
 enum.kickCode = require("dct.libs.kickinfo").kickCode
+
+for _, msntype in pairs(enum.missionType) do
+	assert(enum.squawkMissionType[msntype],
+		"not all mission types are mapped to squawk codes")
+end
 
 return enum

--- a/src/dct/ui/cmds.lua
+++ b/src/dct/ui/cmds.lua
@@ -194,9 +194,9 @@ end
 
 local function briefingmsg(msn, asset)
 	local tgtinfo = msn:getTargetInfo()
+	local iff = msn:getIFFCodes(asset)
 	local msg = string.format("Package: #%s\n", msn:getID())..
-		string.format("IFF Codes: M1(%02o), M3(%04o)\n",
-			msn.iffcodes.m1, msn.iffcodes.m3)..
+		string.format("IFF Codes: M1(%s), M3(%s)\n", iff.m1, iff.m3)..
 		string.format("%s: %s (%s)\n",
 			human.locationhdr(msn.type),
 			dctutils.fmtposition(

--- a/tests/test-ui-cmds.lua
+++ b/tests/test-ui-cmds.lua
@@ -25,7 +25,7 @@ local unit1 = Unit({
 }, grp, "bobplayer")
 
 local briefingtxt = "Package: #5720\n"..
-			"IFF Codes: M1(05), M3(5720)\n"..
+			"IFF Codes: M1(50), M3(5720)\n"..
 			"Target AO: 88°07.38'N 063°27.36'W (TOKYO)\n"..
 			"Briefing:\n"..
 			"We have reason to believe there is"..


### PR DESCRIPTION
This fixes generation of invalid mode 1 IFF codes, as most aircraft allow 0-7 in the first digit, but only 0-3 the second digit, by moving the mission type (1-5) over to the first digit of the code, and also adds a secondary secondary digit to the generated code, so different mission types of the same kind (ie. Strike, BAI, Armed Recon, CAS) have unique mode 1 codes (50, 51, 52, 53).

This also makes so that assets assigned to mission each get an unique (sequential) mode 3 IFF code, wrapping when the last digit reaches the maximum value (7), to not collide with other mission codes. This will hopefully make cooperation with LotATC-based controllers easier if people follow the mission instructions.

All the new settings are now in the enum.lua file, easily editable alongside other mission type definitions.