### PR TITLE
template: allow coalition to be a string

### DIFF
--- a/data/DCT/theaters/Caucasus_dctdemo/BlackSea/airbases/CVN71.dct
+++ b/data/DCT/theaters/Caucasus_dctdemo/BlackSea/airbases/CVN71.dct
@@ -1,6 +1,6 @@
 objtype = "airbase"
 name = "CVN-71 Theodore Roosevelt"
-coalition = 2
+coalition = "blue"
 subordinates = {
 	"VF102",
 }

--- a/src/dct/templates/Template.lua
+++ b/src/dct/templates/Template.lua
@@ -285,7 +285,6 @@ local function getkeys(objtype)
 			["type"]  = "string",
 		}, {
 			["name"]  = "coalition",
-			["type"]  = "number",
 			["check"] = checkside,
 		}, {
 			["name"]    = "uniquenames",


### PR DESCRIPTION
Allows the coalition owner to be specified as either a string or number
in the .dct file. This makes is easier on campaign designers to specify
which side the template should be one without having to remember to
internal numbers DCS specifies.

Closes: #135