### PR TITLE
 Add support for templates with mixed coalitions

### DIFF
--- a/data/DCT/theaters/Caucasus_dctdemo/Novorossiysk/misc/NovoStolenAPCs.dct
+++ b/data/DCT/theaters/Caucasus_dctdemo/Novorossiysk/misc/NovoStolenAPCs.dct
@@ -1,0 +1,4 @@
+objtype = "specialforces"
+intel = 4
+cost = 2
+coalition = "red"

--- a/data/DCT/theaters/Caucasus_dctdemo/Novorossiysk/misc/NovoStolenAPCs.stm
+++ b/data/DCT/theaters/Caucasus_dctdemo/Novorossiysk/misc/NovoStolenAPCs.stm
@@ -1,0 +1,972 @@
+staticTemplate = 
+{
+    ["coalition"] = 
+    {
+        ["neutrals"] = 
+        {
+            ["name"] = "neutrals",
+            ["country"] = 
+            {
+                [1] = 
+                {
+                    ["id"] = 70,
+                    ["name"] = "Algeria",
+                }, -- end of [1]
+                [2] = 
+                {
+                    ["id"] = 83,
+                    ["name"] = "Argentina",
+                }, -- end of [2]
+                [3] = 
+                {
+                    ["id"] = 23,
+                    ["name"] = "Austria",
+                }, -- end of [3]
+                [4] = 
+                {
+                    ["id"] = 65,
+                    ["name"] = "Bahrain",
+                }, -- end of [4]
+                [5] = 
+                {
+                    ["id"] = 86,
+                    ["name"] = "Bolivia",
+                }, -- end of [5]
+                [6] = 
+                {
+                    ["id"] = 64,
+                    ["name"] = "Brazil",
+                }, -- end of [6]
+                [7] = 
+                {
+                    ["id"] = 25,
+                    ["name"] = "Bulgaria",
+                }, -- end of [7]
+                [8] = 
+                {
+                    ["id"] = 63,
+                    ["name"] = "Chile",
+                }, -- end of [8]
+                [9] = 
+                {
+                    ["id"] = 76,
+                    ["name"] = "Cuba",
+                }, -- end of [9]
+                [10] = 
+                {
+                    ["id"] = 84,
+                    ["name"] = "Cyprus",
+                }, -- end of [10]
+                [11] = 
+                {
+                    ["id"] = 29,
+                    ["name"] = "Egypt",
+                }, -- end of [11]
+                [12] = 
+                {
+                    ["id"] = 62,
+                    ["name"] = "Ethiopia",
+                }, -- end of [12]
+                [13] = 
+                {
+                    ["id"] = 30,
+                    ["name"] = "Finland",
+                }, -- end of [13]
+                [14] = 
+                {
+                    ["id"] = 78,
+                    ["name"] = "GDR",
+                }, -- end of [14]
+                [15] = 
+                {
+                    ["id"] = 87,
+                    ["name"] = "Ghana",
+                }, -- end of [15]
+                [16] = 
+                {
+                    ["id"] = 31,
+                    ["name"] = "Greece",
+                }, -- end of [16]
+                [17] = 
+                {
+                    ["id"] = 61,
+                    ["name"] = "Honduras",
+                }, -- end of [17]
+                [18] = 
+                {
+                    ["id"] = 32,
+                    ["name"] = "Hungary",
+                }, -- end of [18]
+                [19] = 
+                {
+                    ["id"] = 33,
+                    ["name"] = "India",
+                }, -- end of [19]
+                [20] = 
+                {
+                    ["id"] = 60,
+                    ["name"] = "Indonesia",
+                }, -- end of [20]
+                [21] = 
+                {
+                    ["id"] = 17,
+                    ["name"] = "Insurgents",
+                }, -- end of [21]
+                [22] = 
+                {
+                    ["id"] = 35,
+                    ["name"] = "Iraq",
+                }, -- end of [22]
+                [23] = 
+                {
+                    ["id"] = 69,
+                    ["name"] = "Italian Social Republic",
+                }, -- end of [23]
+                [24] = 
+                {
+                    ["id"] = 36,
+                    ["name"] = "Japan",
+                }, -- end of [24]
+                [25] = 
+                {
+                    ["id"] = 59,
+                    ["name"] = "Jordan",
+                }, -- end of [25]
+                [26] = 
+                {
+                    ["id"] = 71,
+                    ["name"] = "Kuwait",
+                }, -- end of [26]
+                [27] = 
+                {
+                    ["id"] = 79,
+                    ["name"] = "Lebanon",
+                }, -- end of [27]
+                [28] = 
+                {
+                    ["id"] = 58,
+                    ["name"] = "Libya",
+                }, -- end of [28]
+                [29] = 
+                {
+                    ["id"] = 57,
+                    ["name"] = "Malaysia",
+                }, -- end of [29]
+                [30] = 
+                {
+                    ["id"] = 56,
+                    ["name"] = "Mexico",
+                }, -- end of [30]
+                [31] = 
+                {
+                    ["id"] = 55,
+                    ["name"] = "Morocco",
+                }, -- end of [31]
+                [32] = 
+                {
+                    ["id"] = 88,
+                    ["name"] = "Nigeria",
+                }, -- end of [32]
+                [33] = 
+                {
+                    ["id"] = 73,
+                    ["name"] = "Oman",
+                }, -- end of [33]
+                [34] = 
+                {
+                    ["id"] = 39,
+                    ["name"] = "Pakistan",
+                }, -- end of [34]
+                [35] = 
+                {
+                    ["id"] = 89,
+                    ["name"] = "Peru",
+                }, -- end of [35]
+                [36] = 
+                {
+                    ["id"] = 54,
+                    ["name"] = "Philippines",
+                }, -- end of [36]
+                [37] = 
+                {
+                    ["id"] = 77,
+                    ["name"] = "Portugal",
+                }, -- end of [37]
+                [38] = 
+                {
+                    ["id"] = 72,
+                    ["name"] = "Qatar",
+                }, -- end of [38]
+                [39] = 
+                {
+                    ["id"] = 41,
+                    ["name"] = "Romania",
+                }, -- end of [39]
+                [40] = 
+                {
+                    ["id"] = 42,
+                    ["name"] = "Saudi Arabia",
+                }, -- end of [40]
+                [41] = 
+                {
+                    ["id"] = 44,
+                    ["name"] = "Slovakia",
+                }, -- end of [41]
+                [42] = 
+                {
+                    ["id"] = 85,
+                    ["name"] = "Slovenia",
+                }, -- end of [42]
+                [43] = 
+                {
+                    ["id"] = 75,
+                    ["name"] = "South Africa",
+                }, -- end of [43]
+                [44] = 
+                {
+                    ["id"] = 53,
+                    ["name"] = "Sudan",
+                }, -- end of [44]
+                [45] = 
+                {
+                    ["id"] = 22,
+                    ["name"] = "Switzerland",
+                }, -- end of [45]
+                [46] = 
+                {
+                    ["id"] = 52,
+                    ["name"] = "Thailand",
+                }, -- end of [46]
+                [47] = 
+                {
+                    ["id"] = 66,
+                    ["name"] = "Third Reich",
+                }, -- end of [47]
+                [48] = 
+                {
+                    ["id"] = 51,
+                    ["name"] = "Tunisia",
+                }, -- end of [48]
+                [49] = 
+                {
+                    ["id"] = 74,
+                    ["name"] = "United Arab Emirates",
+                }, -- end of [49]
+                [50] = 
+                {
+                    ["id"] = 82,
+                    ["name"] = "UN",
+                }, -- end of [50]
+                [51] = 
+                {
+                    ["id"] = 7,
+                    ["name"] = "USAF Aggressors",
+                }, -- end of [51]
+                [52] = 
+                {
+                    ["id"] = 68,
+                    ["name"] = "USSR",
+                }, -- end of [52]
+                [53] = 
+                {
+                    ["id"] = 50,
+                    ["name"] = "Venezuela",
+                }, -- end of [53]
+                [54] = 
+                {
+                    ["id"] = 49,
+                    ["name"] = "Vietnam",
+                }, -- end of [54]
+                [55] = 
+                {
+                    ["id"] = 48,
+                    ["name"] = "Yemen",
+                }, -- end of [55]
+                [56] = 
+                {
+                    ["id"] = 67,
+                    ["name"] = "Yugoslavia",
+                }, -- end of [56]
+            }, -- end of ["country"]
+        }, -- end of ["neutrals"]
+        ["blue"] = 
+        {
+            ["name"] = "blue",
+            ["country"] = 
+            {
+                [1] = 
+                {
+                    ["id"] = 21,
+                    ["name"] = "Australia",
+                }, -- end of [1]
+                [2] = 
+                {
+                    ["id"] = 11,
+                    ["name"] = "Belgium",
+                }, -- end of [2]
+                [3] = 
+                {
+                    ["id"] = 8,
+                    ["name"] = "Canada",
+                }, -- end of [3]
+                [4] = 
+                {
+                    ["id"] = 80,
+                    ["name"] = "CJTF Blue",
+                }, -- end of [4]
+                [5] = 
+                {
+                    ["id"] = 28,
+                    ["name"] = "Croatia",
+                }, -- end of [5]
+                [6] = 
+                {
+                    ["id"] = 26,
+                    ["name"] = "Czech Republic",
+                }, -- end of [6]
+                [7] = 
+                {
+                    ["id"] = 13,
+                    ["name"] = "Denmark",
+                }, -- end of [7]
+                [8] = 
+                {
+                    ["id"] = 5,
+                    ["name"] = "France",
+                }, -- end of [8]
+                [9] = 
+                {
+                    ["id"] = 16,
+                    ["name"] = "Georgia",
+                }, -- end of [9]
+                [10] = 
+                {
+                    ["id"] = 6,
+                    ["name"] = "Germany",
+                }, -- end of [10]
+                [11] = 
+                {
+                    ["id"] = 15,
+                    ["name"] = "Israel",
+                }, -- end of [11]
+                [12] = 
+                {
+                    ["id"] = 20,
+                    ["name"] = "Italy",
+                }, -- end of [12]
+                [13] = 
+                {
+                    ["id"] = 12,
+                    ["name"] = "Norway",
+                }, -- end of [13]
+                [14] = 
+                {
+                    ["id"] = 40,
+                    ["name"] = "Poland",
+                }, -- end of [14]
+                [15] = 
+                {
+                    ["id"] = 45,
+                    ["name"] = "South Korea",
+                }, -- end of [15]
+                [16] = 
+                {
+                    ["id"] = 9,
+                    ["name"] = "Spain",
+                }, -- end of [16]
+                [17] = 
+                {
+                    ["id"] = 46,
+                    ["name"] = "Sweden",
+                }, -- end of [17]
+                [18] = 
+                {
+                    ["id"] = 10,
+                    ["name"] = "The Netherlands",
+                }, -- end of [18]
+                [19] = 
+                {
+                    ["id"] = 3,
+                    ["name"] = "Turkey",
+                }, -- end of [19]
+                [20] = 
+                {
+                    ["id"] = 4,
+                    ["name"] = "UK",
+                }, -- end of [20]
+                [21] = 
+                {
+                    ["id"] = 1,
+                    ["name"] = "Ukraine",
+                }, -- end of [21]
+                [22] = 
+                {
+                    ["id"] = 2,
+                    ["static"] = 
+                    {
+                        ["group"] = 
+                        {
+                            [1] = 
+                            {
+                                ["heading"] = 0.95993108859688,
+                                ["route"] = 
+                                {
+                                    ["points"] = 
+                                    {
+                                        [1] = 
+                                        {
+                                            ["alt"] = 0,
+                                            ["type"] = "",
+                                            ["name"] = "",
+                                            ["y"] = 276245.13918146,
+                                            ["speed"] = 0,
+                                            ["x"] = -30748.790874202,
+                                            ["formation_template"] = "",
+                                            ["action"] = "",
+                                        }, -- end of [1]
+                                    }, -- end of ["points"]
+                                }, -- end of ["route"]
+                                ["groupId"] = 69,
+                                ["units"] = 
+                                {
+                                    [1] = 
+                                    {
+                                        ["category"] = "Armor",
+                                        ["type"] = "M-113",
+                                        ["unitId"] = 157,
+                                        ["rate"] = 10,
+                                        ["y"] = 276245.13918146,
+                                        ["x"] = -30748.790874202,
+                                        ["name"] = "Static APC M113-4-1",
+                                        ["heading"] = 0.95993108859688,
+                                    }, -- end of [1]
+                                }, -- end of ["units"]
+                                ["y"] = 276245.13918146,
+                                ["x"] = -30748.790874202,
+                                ["name"] = "Static APC M113-4",
+                                ["dead"] = false,
+                            }, -- end of [1]
+                            [2] = 
+                            {
+                                ["heading"] = 0.95993108859688,
+                                ["route"] = 
+                                {
+                                    ["points"] = 
+                                    {
+                                        [1] = 
+                                        {
+                                            ["alt"] = 0,
+                                            ["type"] = "",
+                                            ["name"] = "",
+                                            ["y"] = 276249.17953902,
+                                            ["speed"] = 0,
+                                            ["x"] = -30754.14527467,
+                                            ["formation_template"] = "",
+                                            ["action"] = "",
+                                        }, -- end of [1]
+                                    }, -- end of ["points"]
+                                }, -- end of ["route"]
+                                ["groupId"] = 70,
+                                ["units"] = 
+                                {
+                                    [1] = 
+                                    {
+                                        ["category"] = "Armor",
+                                        ["type"] = "M-113",
+                                        ["unitId"] = 158,
+                                        ["rate"] = 10,
+                                        ["y"] = 276249.17953902,
+                                        ["x"] = -30754.14527467,
+                                        ["name"] = "Static APC M113-5-1",
+                                        ["heading"] = 0.95993108859688,
+                                    }, -- end of [1]
+                                }, -- end of ["units"]
+                                ["y"] = 276249.17953902,
+                                ["x"] = -30754.14527467,
+                                ["name"] = "Static APC M113-5",
+                                ["dead"] = false,
+                            }, -- end of [2]
+                            [3] = 
+                            {
+                                ["heading"] = 0.95993108859688,
+                                ["route"] = 
+                                {
+                                    ["points"] = 
+                                    {
+                                        [1] = 
+                                        {
+                                            ["alt"] = 0,
+                                            ["type"] = "",
+                                            ["name"] = "",
+                                            ["y"] = 276233.76973931,
+                                            ["speed"] = 0,
+                                            ["x"] = -30732.79244489,
+                                            ["formation_template"] = "",
+                                            ["action"] = "",
+                                        }, -- end of [1]
+                                    }, -- end of ["points"]
+                                }, -- end of ["route"]
+                                ["groupId"] = 73,
+                                ["units"] = 
+                                {
+                                    [1] = 
+                                    {
+                                        ["category"] = "Armor",
+                                        ["type"] = "M-113",
+                                        ["unitId"] = 164,
+                                        ["rate"] = 10,
+                                        ["y"] = 276233.76973931,
+                                        ["x"] = -30732.79244489,
+                                        ["name"] = "Static APC M113-1-1",
+                                        ["heading"] = 0.95993108859688,
+                                    }, -- end of [1]
+                                }, -- end of ["units"]
+                                ["y"] = 276233.76973931,
+                                ["x"] = -30732.79244489,
+                                ["name"] = "Static APC M113-1",
+                                ["dead"] = false,
+                            }, -- end of [3]
+                            [4] = 
+                            {
+                                ["heading"] = 0.95993108859688,
+                                ["route"] = 
+                                {
+                                    ["points"] = 
+                                    {
+                                        [1] = 
+                                        {
+                                            ["alt"] = 0,
+                                            ["type"] = "",
+                                            ["name"] = "",
+                                            ["y"] = 276237.26178226,
+                                            ["speed"] = 0,
+                                            ["x"] = -30737.746273256,
+                                            ["formation_template"] = "",
+                                            ["action"] = "",
+                                        }, -- end of [1]
+                                    }, -- end of ["points"]
+                                }, -- end of ["route"]
+                                ["groupId"] = 74,
+                                ["units"] = 
+                                {
+                                    [1] = 
+                                    {
+                                        ["category"] = "Armor",
+                                        ["type"] = "M-113",
+                                        ["unitId"] = 165,
+                                        ["rate"] = 10,
+                                        ["y"] = 276237.26178226,
+                                        ["x"] = -30737.746273256,
+                                        ["name"] = "Static APC M113-2-1",
+                                        ["heading"] = 0.95993108859688,
+                                    }, -- end of [1]
+                                }, -- end of ["units"]
+                                ["y"] = 276237.26178226,
+                                ["x"] = -30737.746273256,
+                                ["name"] = "Static APC M113-2",
+                                ["dead"] = false,
+                            }, -- end of [4]
+                            [5] = 
+                            {
+                                ["heading"] = 0.95993108859688,
+                                ["route"] = 
+                                {
+                                    ["points"] = 
+                                    {
+                                        [1] = 
+                                        {
+                                            ["alt"] = 0,
+                                            ["type"] = "",
+                                            ["name"] = "",
+                                            ["y"] = 276241.03806126,
+                                            ["speed"] = 0,
+                                            ["x"] = -30742.903127374,
+                                            ["formation_template"] = "",
+                                            ["action"] = "",
+                                        }, -- end of [1]
+                                    }, -- end of ["points"]
+                                }, -- end of ["route"]
+                                ["groupId"] = 75,
+                                ["units"] = 
+                                {
+                                    [1] = 
+                                    {
+                                        ["category"] = "Armor",
+                                        ["type"] = "M-113",
+                                        ["unitId"] = 166,
+                                        ["rate"] = 10,
+                                        ["y"] = 276241.03806126,
+                                        ["x"] = -30742.903127374,
+                                        ["name"] = "Static APC M113-3-1",
+                                        ["heading"] = 0.95993108859688,
+                                    }, -- end of [1]
+                                }, -- end of ["units"]
+                                ["y"] = 276241.03806126,
+                                ["x"] = -30742.903127374,
+                                ["name"] = "Static APC M113-3",
+                                ["dead"] = false,
+                            }, -- end of [5]
+                        }, -- end of ["group"]
+                    }, -- end of ["static"]
+                    ["name"] = "USA",
+                }, -- end of [22]
+            }, -- end of ["country"]
+        }, -- end of ["blue"]
+        ["red"] = 
+        {
+            ["name"] = "red",
+            ["country"] = 
+            {
+                [1] = 
+                {
+                    ["id"] = 18,
+                    ["name"] = "Abkhazia",
+                }, -- end of [1]
+                [2] = 
+                {
+                    ["id"] = 24,
+                    ["name"] = "Belarus",
+                }, -- end of [2]
+                [3] = 
+                {
+                    ["id"] = 27,
+                    ["name"] = "China",
+                }, -- end of [3]
+                [4] = 
+                {
+                    ["id"] = 81,
+                    ["name"] = "CJTF Red",
+                }, -- end of [4]
+                [5] = 
+                {
+                    ["id"] = 34,
+                    ["name"] = "Iran",
+                }, -- end of [5]
+                [6] = 
+                {
+                    ["id"] = 37,
+                    ["name"] = "Kazakhstan",
+                }, -- end of [6]
+                [7] = 
+                {
+                    ["id"] = 38,
+                    ["name"] = "North Korea",
+                }, -- end of [7]
+                [8] = 
+                {
+                    ["id"] = 0,
+                    ["vehicle"] = 
+                    {
+                        ["group"] = 
+                        {
+                            [1] = 
+                            {
+                                ["visible"] = false,
+                                ["tasks"] = 
+                                {
+                                }, -- end of ["tasks"]
+                                ["uncontrollable"] = false,
+                                ["task"] = "Ground Nothing",
+                                ["route"] = 
+                                {
+                                    ["spans"] = 
+                                    {
+                                    }, -- end of ["spans"]
+                                    ["points"] = 
+                                    {
+                                        [1] = 
+                                        {
+                                            ["alt"] = 116,
+                                            ["type"] = "Turning Point",
+                                            ["ETA"] = 0,
+                                            ["alt_type"] = "BARO",
+                                            ["formation_template"] = "",
+                                            ["y"] = 276259.82599367,
+                                            ["x"] = -30773.795013882,
+                                            ["ETA_locked"] = true,
+                                            ["speed"] = 0,
+                                            ["action"] = "Off Road",
+                                            ["task"] = 
+                                            {
+                                                ["id"] = "ComboTask",
+                                                ["params"] = 
+                                                {
+                                                    ["tasks"] = 
+                                                    {
+                                                    }, -- end of ["tasks"]
+                                                }, -- end of ["params"]
+                                            }, -- end of ["task"]
+                                            ["speed_locked"] = true,
+                                        }, -- end of [1]
+                                    }, -- end of ["points"]
+                                }, -- end of ["route"]
+                                ["groupId"] = 71,
+                                ["hidden"] = false,
+                                ["units"] = 
+                                {
+                                    [1] = 
+                                    {
+                                        ["transportable"] = 
+                                        {
+                                            ["randomTransportable"] = false,
+                                        }, -- end of ["transportable"]
+                                        ["skill"] = "High",
+                                        ["type"] = "Infantry AK",
+                                        ["unitId"] = 159,
+                                        ["y"] = 276259.82599367,
+                                        ["x"] = -30773.795013882,
+                                        ["name"] = "Novo AR-1",
+                                        ["heading"] = 2.5132741228718,
+                                        ["playerCanDrive"] = false,
+                                    }, -- end of [1]
+                                    [2] = 
+                                    {
+                                        ["transportable"] = 
+                                        {
+                                            ["randomTransportable"] = false,
+                                        }, -- end of ["transportable"]
+                                        ["skill"] = "High",
+                                        ["type"] = "Infantry AK",
+                                        ["unitId"] = 160,
+                                        ["y"] = 276255.25465106,
+                                        ["x"] = -30773.500088553,
+                                        ["name"] = "Novo AR-2",
+                                        ["heading"] = 2.5132741228718,
+                                        ["playerCanDrive"] = false,
+                                    }, -- end of [2]
+                                    [3] = 
+                                    {
+                                        ["transportable"] = 
+                                        {
+                                            ["randomTransportable"] = false,
+                                        }, -- end of ["transportable"]
+                                        ["skill"] = "High",
+                                        ["type"] = "Infantry AK",
+                                        ["unitId"] = 161,
+                                        ["y"] = 276263.66002295,
+                                        ["x"] = -30770.255909932,
+                                        ["name"] = "Novo AR-3",
+                                        ["heading"] = 2.5132741228718,
+                                        ["playerCanDrive"] = false,
+                                    }, -- end of [3]
+                                    [4] = 
+                                    {
+                                        ["transportable"] = 
+                                        {
+                                            ["randomTransportable"] = false,
+                                        }, -- end of ["transportable"]
+                                        ["skill"] = "High",
+                                        ["type"] = "Infantry AK",
+                                        ["unitId"] = 162,
+                                        ["y"] = 276258.00107921,
+                                        ["x"] = -30769.452010239,
+                                        ["name"] = "Novo AR-4",
+                                        ["heading"] = 2.5132741228718,
+                                        ["playerCanDrive"] = false,
+                                    }, -- end of [4]
+                                }, -- end of ["units"]
+                                ["y"] = 276259.82599367,
+                                ["x"] = -30773.795013882,
+                                ["name"] = "Primary Destroyed Novo AR",
+                                ["start_time"] = 0,
+                            }, -- end of [1]
+                            [2] = 
+                            {
+                                ["visible"] = false,
+                                ["tasks"] = 
+                                {
+                                }, -- end of ["tasks"]
+                                ["uncontrollable"] = false,
+                                ["task"] = "Ground Nothing",
+                                ["route"] = 
+                                {
+                                    ["spans"] = 
+                                    {
+                                    }, -- end of ["spans"]
+                                    ["points"] = 
+                                    {
+                                        [1] = 
+                                        {
+                                            ["alt"] = 102,
+                                            ["type"] = "Turning Point",
+                                            ["ETA"] = 0,
+                                            ["alt_type"] = "BARO",
+                                            ["formation_template"] = "",
+                                            ["y"] = 276281.50720745,
+                                            ["x"] = -30854.855270808,
+                                            ["ETA_locked"] = true,
+                                            ["speed"] = 0,
+                                            ["action"] = "Off Road",
+                                            ["task"] = 
+                                            {
+                                                ["id"] = "ComboTask",
+                                                ["params"] = 
+                                                {
+                                                    ["tasks"] = 
+                                                    {
+                                                    }, -- end of ["tasks"]
+                                                }, -- end of ["params"]
+                                            }, -- end of ["task"]
+                                            ["speed_locked"] = true,
+                                        }, -- end of [1]
+                                    }, -- end of ["points"]
+                                }, -- end of ["route"]
+                                ["groupId"] = 72,
+                                ["hidden"] = false,
+                                ["units"] = 
+                                {
+                                    [1] = 
+                                    {
+                                        ["transportable"] = 
+                                        {
+                                            ["randomTransportable"] = false,
+                                        }, -- end of ["transportable"]
+                                        ["skill"] = "High",
+                                        ["type"] = "BMP-2",
+                                        ["unitId"] = 163,
+                                        ["y"] = 276281.50720745,
+                                        ["x"] = -30854.855270808,
+                                        ["name"] = "Novo AR SA-9-1",
+                                        ["heading"] = 1.5184364492351,
+                                        ["playerCanDrive"] = true,
+                                    }, -- end of [1]
+                                }, -- end of ["units"]
+                                ["y"] = 276281.50720745,
+                                ["x"] = -30854.855270808,
+                                ["name"] = "Primary Destroyed Novo AR SA-9",
+                                ["start_time"] = 0,
+                            }, -- end of [2]
+                        }, -- end of ["group"]
+                    }, -- end of ["vehicle"]
+                    ["name"] = "Russia",
+                    ["static"] = 
+                    {
+                        ["group"] = 
+                        {
+                            [1] = 
+                            {
+                                ["heading"] = 2.4958208303519,
+                                ["route"] = 
+                                {
+                                    ["points"] = 
+                                    {
+                                        [1] = 
+                                        {
+                                            ["alt"] = 0,
+                                            ["type"] = "",
+                                            ["name"] = "",
+                                            ["y"] = 276256.76511107,
+                                            ["speed"] = 0,
+                                            ["x"] = -30743.327752146,
+                                            ["formation_template"] = "",
+                                            ["action"] = "",
+                                        }, -- end of [1]
+                                    }, -- end of ["points"]
+                                }, -- end of ["route"]
+                                ["groupId"] = 76,
+                                ["units"] = 
+                                {
+                                    [1] = 
+                                    {
+                                        ["category"] = "Fortifications",
+                                        ["shape_name"] = "SetkaKP",
+                                        ["type"] = "FARP Ammo Dump Coating",
+                                        ["unitId"] = 167,
+                                        ["rate"] = 50,
+                                        ["y"] = 276256.76511107,
+                                        ["x"] = -30743.327752146,
+                                        ["name"] = "Static FARP Ammo Storage-1",
+                                        ["heading"] = 2.4958208303519,
+                                    }, -- end of [1]
+                                }, -- end of ["units"]
+                                ["y"] = 276256.76511107,
+                                ["x"] = -30743.327752146,
+                                ["name"] = "Static FARP Ammo Storage-1",
+                                ["dead"] = false,
+                            }, -- end of [1]
+                            [2] = 
+                            {
+                                ["heading"] = 2.5307274153918,
+                                ["route"] = 
+                                {
+                                    ["points"] = 
+                                    {
+                                        [1] = 
+                                        {
+                                            ["alt"] = 0,
+                                            ["type"] = "",
+                                            ["name"] = "",
+                                            ["y"] = 276245.21979742,
+                                            ["speed"] = 0,
+                                            ["x"] = -30727.613297451,
+                                            ["formation_template"] = "",
+                                            ["action"] = "",
+                                        }, -- end of [1]
+                                    }, -- end of ["points"]
+                                }, -- end of ["route"]
+                                ["groupId"] = 77,
+                                ["units"] = 
+                                {
+                                    [1] = 
+                                    {
+                                        ["category"] = "Fortifications",
+                                        ["shape_name"] = "PalatkaB",
+                                        ["type"] = "FARP Tent",
+                                        ["unitId"] = 168,
+                                        ["rate"] = 50,
+                                        ["y"] = 276245.21979742,
+                                        ["x"] = -30727.613297451,
+                                        ["name"] = "Static FARP Tent-1-1",
+                                        ["heading"] = 2.5307274153918,
+                                    }, -- end of [1]
+                                }, -- end of ["units"]
+                                ["y"] = 276245.21979742,
+                                ["x"] = -30727.613297451,
+                                ["name"] = "Static FARP Tent-1",
+                                ["dead"] = false,
+                            }, -- end of [2]
+                        }, -- end of ["group"]
+                    }, -- end of ["static"]
+                }, -- end of [8]
+                [9] = 
+                {
+                    ["id"] = 43,
+                    ["name"] = "Serbia",
+                }, -- end of [9]
+                [10] = 
+                {
+                    ["id"] = 19,
+                    ["name"] = "South Ossetia",
+                }, -- end of [10]
+                [11] = 
+                {
+                    ["id"] = 47,
+                    ["name"] = "Syria",
+                }, -- end of [11]
+            }, -- end of ["country"]
+        }, -- end of ["red"]
+    }, -- end of ["coalition"]
+    ["name"] = "NovoStolenAPCs",
+    ["requiredModules"] = 
+    {
+    }, -- end of ["requiredModules"]
+    ["localization"] = 
+    {
+        ["DEFAULT"] = 
+        {
+            ["DictKey_descriptionNeutralsTask_4"] = "",
+            ["DictKey_sortie_5"] = "",
+            ["DictKey_descriptionText_1"] = "",
+            ["DictKey_descriptionBlueTask_3"] = "",
+            ["DictKey_descriptionRedTask_2"] = "",
+        }, -- end of ["DEFAULT"]
+    }, -- end of ["localization"]
+    ["theatre"] = "Caucasus",
+    ["desc"] = "%LOCATIONMETHOD% a group of captured M113 APCs in an abandoned parking located in the northern sector of Novorossyisk. It is believed that these APCs are still operational, so it is ideal that they are not damaged. Expect light anti-air cover in the immediate area, and avoid flying near the port if any warships are present.\
+\
+Primary Objective: Eliminate Russian troops holding the area.\
+\
+Secondary Objective: Avoid damaging the M113 APCs.\
+\
+Recommended Ordinance: Cannons for infantry and GBU-12s or AGM-65Ds for armored targets.",
+} -- end of staticTemplate

--- a/doc/03-designer.md
+++ b/doc/03-designer.md
@@ -560,15 +560,21 @@ the theater definition directory this region will need to be defined.
 ### `coalition`
 
  * _required:_ depends
- * _value:_ "red", "blue", "neutral" (case doen't matter)
- * _default:_ the coalition the DCS groups/statics belong too or this field
-   is **required**
+ * _value:_ "red", "blue", "neutral"
+ * _default:_ detected based on template
 
-A template can only belong to a single coalition (side) and any DCS
-groups/statics not belonging to the same side as the first group will
-cause a fatal error. This can be confusing sometimes when a template is
-attempted to be used across different campaigns. Your campaign designer
-should come up with a standard country set for each coalition.
+A template can only belong to a single coalition (side). If not specified, it
+will be detected based on units and objects present in the template, but if it
+does not contain anything (ie. an airbase), or contains objects of multiple
+coalitions, this value must be filled.
+
+> Important: units and objects saved in templates belong to countries, but the
+coalitions of those objects in-game will be set based on the settings of the
+.miz file. For example, if you create a template where the USA is a Blue
+country, and then run it in a .miz where the USA is set as a neutral country,
+the units in the template will spawn as neutral. Therefore, mission designers
+should standardize which countries belong to which coalition, so that the
+coalitions in templates are consistent with in-game results.
 
 ### `desc`
 

--- a/src/dct/templates/STM.lua
+++ b/src/dct/templates/STM.lua
@@ -122,7 +122,7 @@ end
 --    }}}
 --]]
 
-function STM.transform(stmdata, file)
+function STM.transform(stmdata)
 	local template   = {}
 	local lookupname =  function(name)
 		if name == nil then
@@ -135,20 +135,6 @@ function STM.transform(stmdata, file)
 		end
 		return newname
 	end
-	local trackUniqueCoalition = function(_, cntryid, _)
-		local side = coalition.getCountryCoalition(cntryid)
-		if template.coalition == nil then
-			template.coalition = side
-		end
-		assert(template.coalition == side, string.format(
-			"runtime error: invalid STM; country(%s) does not belong "..
-			"to '%s' coalition, country belongs to '%s' coalition; file: %s",
-			country.name[cntryid],
-			tostring(utils.getkey(coalition.side, template.coalition)),
-			tostring(utils.getkey(coalition.side, side)),
-			file))
-		return true
-	end
 
 	template.name    = lookupname(stmdata.name)
 	template.theater = lookupname(stmdata.theatre)
@@ -156,11 +142,9 @@ function STM.transform(stmdata, file)
 	template.tpldata = {}
 
 	for _, coa_data in pairs(stmdata.coalition) do
-		for _, grp in ipairs(STM.processCoalition(coa_data,
-				lookupname,
-				trackUniqueCoalition,
-				modifyStatic)) do
-			table.insert(template.tpldata, grp)
+		local groups = STM.processCoalition(coa_data, lookupname, nil, modifyStatic)
+		for _, group in ipairs(groups) do
+			table.insert(template.tpldata, group)
 		end
 	end
 	return template

--- a/src/dct/templates/STM.lua
+++ b/src/dct/templates/STM.lua
@@ -5,7 +5,7 @@
 -- class knows how to deal with.
 --]]
 
-local utils = require("libs.utils")
+local utils    = require("libs.utils")
 
 local categorymap = {
 	["HELICOPTER"] = 'HELICOPTER',
@@ -122,7 +122,7 @@ end
 --    }}}
 --]]
 
-function STM.transform(stmdata)
+function STM.transform(stmdata, file)
 	local template   = {}
 	local lookupname =  function(name)
 		if name == nil then
@@ -139,6 +139,7 @@ function STM.transform(stmdata)
 	template.name    = lookupname(stmdata.name)
 	template.theater = lookupname(stmdata.theatre)
 	template.desc    = lookupname(stmdata.desc)
+	template.file    = file
 	template.tpldata = {}
 
 	for _, coa_data in pairs(stmdata.coalition) do

--- a/src/dct/templates/Template.lua
+++ b/src/dct/templates/Template.lua
@@ -479,23 +479,25 @@ local function validateCoalition(tpl)
 				local groupCoalition = coalition.getCountryCoalition(grp.countryid)
 				tpl.coalition = tpl.coalition or groupCoalition
 				assert(tpl.coalition == groupCoalition, string.format(
-					"template '%s' contains mixed coalitions; one group belongs to "..
+					"'%s': template contains mixed coalitions; one group belongs to "..
 					"country '%s', which is in the '%s' coalition, "..
 					"but another group in the template is in the '%s' coalition\n"..
 					"note: coalition checks are made according to the .miz, not the .stm\n"..
 					"note: if this is intentional, consider setting the coalition "..
-					"manually in the .dct",
+					"manually in the .dct\nfile: %s",
 					tpl.name,
 					country.name[grp.countryid],
 					utils.getkey(coalition.side, groupCoalition),
-					utils.getkey(coalition.side, tpl.coalition)
+					utils.getkey(coalition.side, tpl.coalition),
+					tpl.file or "unknown"
 				))
 			end
 		end
 	end
 	assert(tpl.coalition ~= nil, string.format(
-		"cannot determine the coalition of template '%s' because it has no units; "..
-		"please set it manually in the .dct", tpl.name))
+		"'%s': cannot determine the coalition of template because it has no units; "..
+		"please set it manually in the .dct\nfile: %s",
+		tpl.name, tpl.file or "unknown"))
 end
 
 function Template:validate()

--- a/tests/test-init.lua
+++ b/tests/test-init.lua
@@ -7,11 +7,11 @@ require("dct")
 local function main()
 	dct.init()
 	_G.dct.theater:exec(50)
-	local expected = 32
+	local expected = 34
 	assert(dctcheck.spawngroups == expected,
 		string.format("group spawn broken; expected(%d), got(%d)",
 		expected, dctcheck.spawngroups))
-	expected = 29
+	expected = 36
 	assert(dctcheck.spawnstatics == expected,
 		string.format("static spawn broken; expected(%d), got(%d)",
 		expected, dctcheck.spawnstatics))

--- a/tests/test-theater.lua
+++ b/tests/test-theater.lua
@@ -111,11 +111,11 @@ local function main()
 	_G.dct.theater = theater
 	theater.startdate = startdate
 	theater:exec(50)
-	local expected = 32
+	local expected = 34
 	assert(dctcheck.spawngroups == expected,
 		string.format("group spawn broken; expected(%d), got(%d)",
 		expected, dctcheck.spawngroups))
-	expected = 29
+	expected = 36
 	assert(dctcheck.spawnstatics == expected,
 		string.format("static spawn broken; expected(%d), got(%d)",
 		expected, dctcheck.spawnstatics))

--- a/tests/test-ui-cmds.lua
+++ b/tests/test-ui-cmds.lua
@@ -26,9 +26,9 @@ local unit1 = Unit({
 
 local briefingtxt = "Package: #5720\n"..
 			"IFF Codes: M1(50), M3(5720)\n"..
-			"Target AO: 88°07.38'N 063°27.36'W (TOKYO)\n"..
+			"Target AO: 88°07.38'N 063°27.36'W (DALLAS)\n"..
 			"Briefing:\n"..
-			"We have reason to believe there is"..
+			"Reconnaissance elements have located"..
 			" a fuel storage facility at 88°07.38'N 063°27.36'W,"..
 			" East of Krasnodar-Center.\n\n"..
 			"Primary Objectives: Destroy the fuel tanks embedded in "..


### PR DESCRIPTION
This allows a template to contain groups of more than one, on the condition that it is specified in the template's .dct. This can be useful for things such as adding friendly JTACs that are linked to a specific conflict, TACAN navigation beacons, or even friendly troops that can be transported to an objective (via the game's built-in unit transport system).

If the template doesn't have any targets specified, goals will only be auto-generated for objects that belong to the same coalition as the template, but the mission designer is free to explicitly mark neutral or even friendly units as targets (if they find an use case for it).

This also fixes #135 by removing the type requirement from the `coalition` key in templates. The validation method still checks that the input is valid, either in number or string form, or continues if nil (so that auto-detection may be applied).

A new template has been added to the demo theater to test validation of this new feature automatically.