### PR TITLE
Add object ID writeback on spawn

### DIFF
--- a/src/dcttestlibs/dcsstubs.lua
+++ b/src/dcttestlibs/dcsstubs.lua
@@ -768,6 +768,7 @@ function Unit:__init(objdata, group, pname)
 		group:_addUnit(self)
 	end
 	self.pname = pname
+	objdata.unitId = self:getID()
 end
 Unit.Category = {
 	["AIRPLANE"]    = 0,
@@ -819,6 +820,7 @@ function StaticObject:__init(objdata)
 	objdata.category = Object.Category.STATIC
 	Coalition.__init(self, objdata)
 	self.clife = self.desc.life
+	objdata.unitId = self:getID()
 end
 
 StaticObject.Category = {
@@ -866,6 +868,7 @@ function Group:__init(unitcnt, objdata)
 	self.getVelocity = nil
 	self.inair = nil
 	self.inAir = nil
+	objdata.groupId = self:getID()
 end
 
 Group.Category = {


### PR DESCRIPTION
This replicates an anti-pattern of DCS of writing back IDs to the spawn data table to the DCS stubs. Currently, that does not cause any bugs, as the spawn data is deep-copied before use, so tests will pass, but if the deep copy is removed later, such as to re-use IDs when an asset is de-spawned and later spawned again, there needs to be special treatment to not save any runtime IDs when marshaling assets, so this change makes tests fail if the treatment is incomplete.
