### PR TITLE
build: update release file structure for ease of use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 MAKEFLAGS  := --no-print-directory
 SRCPATH    := $(CURDIR)
 BUILDPATH  ?= $(CURDIR)/build
+MODPATH    := $(BUILDPATH)/Mods/Tech/DCT
 VERSION    ?= $(shell git describe)
 LUALIBSVER := 6
 LUALIBSAR  := v$(LUALIBSVER).zip
@@ -13,32 +14,32 @@ check:
 	@$(MAKE) -C tests
 
 build:
-	mkdir -p $(BUILDPATH)/DCT/lua
-	cp -a $(SRCPATH)/src/dct.lua $(SRCPATH)/src/dct/ $(BUILDPATH)/DCT/lua
+	mkdir -p $(BUILDPATH)/Mods/Tech/DCT/lua
+	cp -a $(SRCPATH)/src/dct.lua $(SRCPATH)/src/dct/ $(BUILDPATH)/Mods/Tech/DCT/lua
 	sed -e "s:%VERSION%:$(VERSION):" $(SRCPATH)/entry.lua.tpl > \
-		$(BUILDPATH)/DCT/entry.lua
+		$(BUILDPATH)/Mods/Tech/DCT/entry.lua
 	sed -e "s:%VERSION%:$(VERSION):" $(SRCPATH)/src/dct.lua > \
-		$(BUILDPATH)/DCT/lua/dct.lua
-	cp -a $(SRCPATH)/mission $(BUILDPATH)/DCT/
-	mkdir -p $(BUILDPATH)/HOOKS
-	cp -a $(SRCPATH)/hooks/* $(BUILDPATH)/HOOKS/
-	mkdir -p $(BUILDPATH)/DEMO/
-	cp -a $(SRCPATH)/data/DCT $(SRCPATH)/data/Config \
-		$(SRCPATH)/data/README.md $(BUILDPATH)/DEMO/
-	(mkdir -p $(BUILDPATH)/DEMO/demomiz; \
-		cd $(BUILDPATH)/DEMO/demomiz; \
+		$(BUILDPATH)/Mods/Tech/DCT/lua/dct.lua
+	mkdir -p $(BUILDPATH)/Scripts/Hooks
+	cp -a $(SRCPATH)/mission/* $(BUILDPATH)/Scripts/
+	cp -a $(SRCPATH)/hooks/* $(BUILDPATH)/Scripts/Hooks/
+	mkdir -p $(BUILDPATH)/Config/
+	cp -a $(SRCPATH)/data/Config/dct.cfg $(BUILDPATH)/Config/dct.cfg
+	mkdir -p $(BUILDPATH)/DCT/
+	cp -a $(SRCPATH)/data/DCT/* $(BUILDPATH)/DCT/
+	mkdir -p $(BUILDPATH)/Missions
+	(mkdir -p $(BUILDPATH)/demomiz; \
+		cd $(BUILDPATH)/demomiz; \
 		cp -a $(SRCPATH)/data/mission/* .; \
 		cp $(SRCPATH)/mission/* l10n/DEFAULT/; \
-		zip -r "../dct-demo-mission.miz" .; \
-		cd ..; \
-		rm -rf demomiz)
+		zip -r "../Missions/dct-demo-mission.miz" .)
 	cp $(SRCPATH)/README.md $(BUILDPATH)/
 	mkdir -p $(BUILDPATH)/temp
 	(cd $(BUILDPATH)/temp; \
-		wget -q $(LUALIBSURL) >/dev/null; \
-		unzip $(LUALIBSAR) >/dev/null; \
-		cp -a $(LUALIBSDIR)/src/libs* $(BUILDPATH)/DCT/lua)
+		wget -nv $(LUALIBSURL) >/dev/null && \
+		unzip $(LUALIBSAR) >/dev/null && \
+		cp -a $(LUALIBSDIR)/src/libs* $(BUILDPATH)/Mods/Tech/DCT/lua)
 	(cd $(BUILDPATH); \
-		zip -r "DCT-$(VERSION).zip" HOOKS DCT DEMO README.md; \
+		zip -r "DCT-$(VERSION).zip" Config DCT Missions Mods Scripts README.md && \
 		mv DCT-$(VERSION).zip ../)
 	rm -rf $(BUILDPATH)

--- a/data/DCT/theaters/Caucasus_dctdemo/README.md
+++ b/data/DCT/theaters/Caucasus_dctdemo/README.md
@@ -1,21 +1,19 @@
-DESCRIPTION
+## DESCRIPTION
 
 This is a demo theater for the Dynamic Campaign Tools (DCT) Framework.
 It contains a handful of templates of various types in multiple regions to demonstrate use of DCT.
 
 
-INSTALLATION
+## INSTALLATION
 
 1) Install the latest release of DCT, found at - https://github.com/jtoppins/dct/releases.
 
-2) Move the contents of the "CONFIG" Folder into your SavedGames\DCS.openbeta\Config file.
-The contained file, (dct.cfg), contains the settings for the DCT install, such as theater path, state path, and debugging.
+2) If this is your first install, move the contents of the "Config" Folder into your `Saved Games\DCS.openbeta\Config` folder.
+The contained file, (dct.cfg), contains the default settings for the DCT install, such as theater path, state path, and debug logging.
 
-3) Move the "THEATER" folder to the location you have defined in dct.cfg.
-As standard, we have simply left the theater folder in the root DCS.openbeta folder.
+3) Move the "DCT", "Mods" and "Missions" folders into your `Saved Games\DCS.openbeta` folder.
 
-4) Take the example mission from the "MISSIONS" folder and run it as normal.
-At the 20 second mark, all templates should load in and slots will become unlocked.
+4) Run `dct-demo-mission.miz` in the game. At the 20 second mark, all templates should load in and slots will become unlocked.
 
 NOTES: 
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,20 +8,14 @@ permalink: /quick-start
 # Quick Start Guide
 
 1. **Download:** [latest release]({{ site.release_link }})
-2. **Unzip** downloaded release
-3. **Install** the `DCT` folder to your DCS mod folder `<dcs-saved-games>/Mods/tech`
-   - _Note:_ If the path does not exist just create it. If installed properly DCT
-     will be displayed as a module in the game's module manager.
-4. **Install hooks** by moving `HOOKS/dct-hook.lua` to the hooks directory in your
-   DCS Saved Games folder.
-5. **Install Demo** by moving both the `DCT` and `Config` folders in the `DEMO`
-   folder to your DCS saved games folder. Move the demo mission `dct-demo-mission.miz`
-   to where you store your missions.
-6. **Prepare DCS** by removing the following lines of
-   your `DCS World\Scripts\MissionScripting.lua` file.
-   - **WARNING:** unsanitizing your server's environment could leave it open to data
-     loss or corruption of your system if you run a mission or scripts you do not
-     understand.
+2. **Unzip** downloaded release into your `Saved Games\DCS` folder
+    - **NOTE:** if updating DCT, do not replace the Config folder!
+3. **Prepare DCS** by deleting the marked lines in your
+  `Program Files\DCS World\Scripts\MissionScripting.lua` file to allow DCT to read settings
+  and save the state file.
+    - **WARNING:** this will allow any mission or server you play on to access the internet
+    and modify your files, allowing a malicious mission to download and install viruses.
+    **Restore the file or repair the game before running any untrusted missions!**
 
 ```diff
   --Initialization script for the Mission lua Environment (SSE)
@@ -43,10 +37,10 @@ permalink: /quick-start
 -   sanitizeModule('io')
 -   sanitizeModule('lfs')
 -   _G['require'] = nil
--   _G['loadlib'] = nil
-    _G['package'] = nil
+-   _G['package'] = nil
   end
 ```
-7. **Launch the game** and run the demo mission in a multiplayer session.
+
+4. **Launch the game** and run the demo mission in a multiplayer session.
    - _Note:_ It will take at least 20 seconds for all the templates to spawn.
    During this time player slots will be locked.


### PR DESCRIPTION
Updates the release and dev builds to be structured in a drop-in manner (DCT, Missions, Config, Mods, etc folders set up as in the final install), and documentation alongside with it.

Related issue: #69 

Let me know if the documentation can be improved further.