### PR TITLE
tickets: remove need to setup end mission triggers

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -11,6 +11,7 @@ read_globals = {
 	"md5",
 
 	-- DCS specific globals
+	"net",
 	"atmosphere",
 	"country",
 	"env",

--- a/src/dct/libs/Marshallable.lua
+++ b/src/dct/libs/Marshallable.lua
@@ -36,12 +36,13 @@ end
 -- Marshal the object for serialization.
 -- Returns: table representing object
 --]]
-function Marshallable:marshal()
+function Marshallable:marshal(copy)
+	copy = copy or utils.shallowclone
 	local tbl = {}
 	for attribute, _ in pairs(self._marshalnames or {}) do
 		assert(type(self[attribute]) ~= "function",
 			"value error: cannot marshal functions")
-		tbl[attribute] = self[attribute]
+		tbl[attribute] = copy(self[attribute])
 	end
 	if next(tbl) == nil then
 		return nil

--- a/src/dct/systems/tickets.lua
+++ b/src/dct/systems/tickets.lua
@@ -3,102 +3,182 @@
 --- Defines the accounting of a ticket system.
 
 require("math")
-local class    = require("libs.class")
+local class    = require("libs.namedclass")
 local utils    = require("libs.utils")
 local Timer    = require("dct.libs.Timer")
 local Marshallable = require("dct.libs.Marshallable")
 local Command  = require("dct.libs.Command")
+local Check    = require("dct.templates.checkers.Check")
 local UPDATE_TIME = 120
 
-local function checkvalue(keydata, tbl)
-	if tbl[keydata.name] >= 0 then
-		return true
-	end
-	return false
-end
+local difficulty = {
+	["EASY"] = {
+		["player_cost"]     = 1.0,
+		["modifier_loss"]   = 0.5,
+		["modifier_reward"] = 1.5,
+	},
+	["NORMAL"] = {
+		["player_cost"]     = 1.0,
+		["modifier_loss"]   = 1.0,
+		["modifier_reward"] = 1.0,
+	},
+	["HARD"] = {
+		["player_cost"]     = 1.0,
+		["modifier_loss"]   = 1.5,
+		["modifier_reward"] = 0.5,
+	},
+	["REALISTIC"] = {
+		["player_cost"]     = 1.0,
+		["modifier_loss"]   = 1.0,
+		["modifier_reward"] = 0,
+	},
+	["CUSTOM"] = {},
+}
 
-local function checkdifficulty(keydata, tbl)
-	local val = string.lower(tbl[keydata.name])
-	local settings = {
-		["easy"] = {
-			["player_cost"]     = 1.0,
-			["modifier_loss"]   = 0.5,
-			["modifier_reward"] = 1.5,
+local CheckSide = class("CheckSide", Check)
+function CheckSide:__init()
+	Check.__init(self, "Coalition Options", {
+		["tickets"] = {
+			["type"]    = Check.valuetype.UINT,
+			["description"] = [[
+Number of tickets the side's ticket pool starts with. The Neutral
+faction can start with zero tickets all others must have above zero.]],
 		},
-		["normal"] = {
-			["player_cost"]     = 1.0,
-			["modifier_loss"]   = 1.0,
-			["modifier_reward"] = 1.0,
-		},
-		["hard"] = {
-			["player_cost"]     = 1.0,
-			["modifier_loss"]   = 1.5,
-			["modifier_reward"] = 0.5,
-		},
-		["realistic"] = {
-			["player_cost"]     = 1.0,
-			["modifier_loss"]   = 1.0,
-			["modifier_reward"] = 0,
-		},
-		["custom"] = {
-		},
-	}
-
-	if settings[val] == nil then
-		return false
-	end
-	for k, v in pairs(settings[val]) do
-		tbl[k] = v
-	end
-	return true
-end
-
-local function sanatize(keydata, tbl)
-	tbl[keydata.name] = string.gsub(tbl[keydata.name], '["]', "\\\"")
-end
-
-local function checkside(keydata, tbl)
-	local keys = {
-		{
-			["name"]    = "tickets",
-			["type"]    = "number",
-			["check"]   = checkvalue,
-		}, {
-			["name"]    = "player_cost",
-			["type"]    = "number",
-			["check"]   = checkvalue,
+		["player_cost"] = {
+			["type"]    = Check.valuetype.UINT,
 			["default"] = 1,
-		}, {
-			["name"]    = "modifier_reward",
-			["type"]    = "number",
-			["check"]   = checkvalue,
+			["description"] = [[
+Defines the cost of each player slot.]],
+		},
+		["modifier_reward"] = {
+			["type"]    = Check.valuetype.UINT,
 			["default"] = 1,
-		}, {
-			["name"]    = "modifier_loss",
-			["type"]    = "number",
-			["check"]   = checkvalue,
+			["description"] = [[
+Defines the multiplicative modifier that is applied to all rewards the
+given faction receives.]],
+		},
+		["modifier_loss"] = {
+			["type"]    = Check.valuetype.UINT,
 			["default"] = 1,
-		}, {
-			["name"]    = "difficulty",
-			["type"]    = "string",
-			["check"]   = checkdifficulty,
-			["default"] = "custom",
-		}, {
-			["name"]    = "win_message",
-			["type"]    = "string",
-			["check"]   = sanatize,
+			["description"] = [[
+Defines the multiplicative modifier that is applied to all losses the
+given faction takes.]],
+		},
+		["difficulty"] = {
+			["type"]    = Check.valuetype.TABLEKEYS,
+			["values"]  = difficulty,
+			["default"] = difficulty.CUSTOM,
+			["description"] = [[
+Defines some predefined settings for player_cost, modifier_reward, and
+modifier_loss. If this is set to anything other than `custom` any
+explicitly defined values for player_cost, etc will be overwritten.
+
+%VALUES%]],
+		},
+		["win_message"] = {
+			["type"]    = Check.valuetype.STRING,
 			["default"] = "winner",
-		}
-	}
+			["description"] = [[
+]],
+		},
+	}, [[Each coalition definition is required and can have the
+following possible options.]])
+end
 
-	tbl[keydata.name].path = tbl.path
-	utils.checkkeys(keys, tbl[keydata.name])
-	tbl[keydata.name].path = nil
-	tbl[keydata.name].start = tbl[keydata.name].tickets
+function CheckSide:check(data)
+	local ok, key, msg = Check.check(self, data)
+
+	if not ok then
+		return false, key, msg
+	end
+
+	data.start = data.tickets
+	data.win_message = string.gsub(data.win_message, '["]', "\\\"")
+	for k, v in pairs(data.difficulty) do
+		data[k] = v
+	end
+
 	return true
 end
 
-local Tickets = class(Marshallable)
+local CheckGoals = class("CheckGoals", Check)
+function CheckGoals:__init()
+	Check.__init(self, "Goals", {
+		["time"] = {
+			["default"] = -1,
+			["type"]    = Check.valuetype.INT,
+			["description"] = [[
+The total time, in seconds, the campaign will run before a winner is
+determined and a new state is generated. Set to zero to disable the
+timer.]],
+		},
+		["red"] = {
+			["type"]    = Check.valuetype.TABLE,
+			["description"] = [[
+Table defining the RED coalition's starting tickets, difficulity, and win
+message.]],
+		},
+		["blue"] = {
+			["type"]    = Check.valuetype.TABLE,
+			["description"] = [[
+Table defining the BLUE coalition's starting tickets, difficulity, and win
+message.]],
+		},
+		["neutral"] = {
+			["type"]    = Check.valuetype.TABLE,
+			["description"] = [[
+Table defining the NEUTRAL coalition's starting tickets, difficulity, and
+win message.]],
+		},
+	}, [[
+Theater goals define the way in which DCT will evaluate the completion
+of the campaign. It is a simple ticket system much like what is present
+in many AAA FPS titles.
+
+An Example:
+
+**file location:** `<theater-root>/theater.goals`
+
+```lua
+time = 43200  -- 12 hours in seconds
+blue = {
+	tickets         = 100,
+	player_cost     = 1,
+	modifier_reward = 0.5,
+	modifier_loss   = 0.2,
+}
+
+neutral = {
+	tickets = 0,
+}
+
+red = {
+	tickets    = 200,
+	difficulty = "easy",
+}
+```]])
+end
+
+function CheckGoals:check(data)
+	local ok, key, msg = Check.check(self, data)
+
+	if not ok then
+		return false, key, msg
+	end
+
+	local checkside = CheckSide()
+
+	for _, side in pairs({"red", "blue", "neutral"}) do
+		ok, key, msg = checkside:check(data[side])
+
+		if not ok then
+			return false, side.."."..key, msg
+		end
+	end
+	return true
+end
+
+local Tickets = class("Tickets", Marshallable)
 function Tickets:__init(theater)
 	Marshallable.__init(self)
 	self.cfgfile = dct.settings.server.theaterpath..utils.sep..
@@ -146,30 +226,13 @@ end
 
 function Tickets:readconfig()
 	local goals = utils.readlua(self.cfgfile)
-	local keys = {
-		{
-			["name"]    = "time",
-			["type"]    = "number",
-			["check"]   = checkvalue,
-			["default"] = -1
-		}, {
-			["name"]    = "red",
-			["type"]    = "table",
-			["check"]   = checkside,
-		}, {
-			["name"]    = "blue",
-			["type"]    = "table",
-			["check"]   = checkside,
-		}, {
-			["name"]    = "neutral",
-			["type"]    = "table",
-			["check"]   = checkside,
-		}
-	}
+	local checker = CheckGoals()
+	local ok, key, msg = checker:check(goals)
 
-	goals.path = self.cfgfile
-	utils.checkkeys(keys, goals)
-	goals.path = nil
+	if not ok then
+		error(string.format("invalid `%s` %s; file: %s",
+			tostring(key), tostring(msg), tostring(self.cfgfile)))
+	end
 
 	if goals.time > 0 then
 		self.timer = Timer(goals.time, timer.getAbsTime)

--- a/src/dct/templates/checkers/Check.lua
+++ b/src/dct/templates/checkers/Check.lua
@@ -28,6 +28,7 @@ local valuetype = {
 	["LISTKEYS"]  = 9, -- is a list of table keys
 	["LIST"]      = 10, -- a list where all values are of the
 			    --  specified type
+	["UINT"]      = 11, -- unsigned number
 }
 
 --- Used when the item being checked has a single value but from
@@ -137,6 +138,16 @@ local function check_list(data, key, values)
         return true, data[key]
 end
 
+--- verify the value is an unsigned number
+local function check_uint(data, key)
+	local ok, val = check_int(data, key)
+
+	if not ok or val < 0 then
+		return false
+	end
+	return true, val
+end
+
 local checktbl = {
 	[valuetype.VALUES] = check_values,
 	[valuetype.INT]    = check_int,
@@ -148,6 +159,7 @@ local checktbl = {
 	[valuetype.POINT]  = check_point,
 	[valuetype.LISTKEYS] = check_list_keys,
 	[valuetype.LIST]   = check_list,
+	[valuetype.UINT]   = check_uint,
 }
 
 local value_header = {
@@ -158,6 +170,7 @@ local value_header = {
 	[valuetype.BOOL]      = "boolean (true/false)",
 	[valuetype.TABLEKEYS] = "specific values",
 	[valuetype.TABLE]     = "table",
+	[valuetype.UINT]      = "positive number",
 }
 
 local function is_required(option)

--- a/src/dct/templates/checkers/Check.lua
+++ b/src/dct/templates/checkers/Check.lua
@@ -2,6 +2,7 @@
 
 local class = require("libs.namedclass")
 local utils = require("libs.utils")
+local dctutils = require("dct.libs.utils")
 local vector = require("dct.libs.vector")
 
 local rc = {
@@ -149,6 +150,107 @@ local checktbl = {
 	[valuetype.LIST]   = check_list,
 }
 
+local value_header = {
+	[valuetype.VALUES]    = "specific values",
+	[valuetype.INT]       = "number",
+	[valuetype.RANGE]     = "range",
+	[valuetype.STRING]    = "string",
+	[valuetype.BOOL]      = "boolean (true/false)",
+	[valuetype.TABLEKEYS] = "specific values",
+	[valuetype.TABLE]     = "table",
+}
+
+local function is_required(option)
+	local s = " - _required:_ "
+
+	if option.default ~= nil then
+		s = s.."no"
+
+		if not (option.default == "") and
+		   type(option.default) ~= "table" and
+		   option.type ~= valuetype.VALUES then
+			s = s.."\n - _default:_ "..tostring(option.default)
+		elseif option.type == valuetype.VALUES then
+			local found = nil
+			for key, data in pairs(option.values) do
+				if data.value == option.default then
+					found = key
+					break
+				end
+			end
+
+			if found ~= nil then
+				s = s.."\n - _default:_ "..tostring(found)
+			end
+		end
+	else
+		s = s.."yes"
+	end
+	return s
+end
+
+local function option_summary(option)
+	local summary = is_required(option).."\n"
+
+	summary = summary.." - _value:_ "..value_header[option.type]
+	if option.type == valuetype.RANGE then
+		summary = summary..string.format(" [%d, %d]",
+			option.values[1], option.values[2])
+	end
+	summary = summary.."\n"
+	if option.agent then
+		summary = summary.." - _agent:_ true\n"
+	end
+	if option.deprecated then
+		summary = summary.."\n_NOTE: this option has been "..
+			  "deprecated._\n"
+	end
+	return summary
+end
+
+local function option_description(option)
+	local desc = option.description.."\n"
+
+	if option.type == valuetype.VALUES or
+	   option.type == valuetype.TABLEKEYS or
+	   (option.type == valuetype.TABLE and
+	    option.values ~= nil) then
+		local values = ""
+		for k, v in utils.sortedpairs(option.values) do
+			values = values.." - `"..k.."`"
+			if option.type == valuetype.VALUES then
+				values = values.." - "..v.description
+			end
+			values = values.."\n"
+		end
+		local len = string.len(values)
+		values = string.sub(values, 1, len - 1)
+
+		desc = dctutils.interp(desc, {
+			["VALUES"] = values,
+		})
+	end
+	return desc
+end
+
+local function write_section(level, name, data)
+	if next(data.options) == nil then
+		return
+	end
+
+	print(string.format("\n%s %s\n", string.rep("#", level), name))
+	if data.description then
+		print(data.description)
+	end
+
+	for optname, optdata in utils.sortedpairs(data.options) do
+		print(string.format("\n%s `%s`\n",
+				    string.rep("#", level+1), optname))
+		print(option_summary(optdata))
+		print(option_description(optdata))
+	end
+end
+
 local Check = class("Check")
 function Check:__init(section, options, description)
 	options = options or {}
@@ -170,6 +272,35 @@ end
 Check.rc = rc
 Check.reasontext = texttbl
 Check.valuetype = valuetype
+
+--- class function to generate check documentation.
+-- Generate markdown styled documentation for all options checked for by
+-- the given set of checkers. Output to standard out.
+function Check.genDocs(header, checkers)
+	local sections = {}
+	for _, c in pairs(checkers) do
+		local doc = c:doc()
+		if sections[doc.section] == nil and next(doc.options) then
+			sections[doc.section] = {}
+			sections[doc.section]["options"] = {}
+		end
+
+		if doc.description then
+			sections[doc.section]["description"] = doc.description
+		end
+
+		for key, val in pairs(doc.options) do
+			if val.nodoc ~= true then
+				sections[doc.section]["options"][key] = val
+			end
+		end
+	end
+
+	print(header)
+	for name, data in utils.sortedpairs(sections) do
+		write_section(2, name, data)
+	end
+end
 
 --- checks the if the options in data have legal values
 --

--- a/src/dcttestlibs/dcsstubs.lua
+++ b/src/dcttestlibs/dcsstubs.lua
@@ -1468,3 +1468,11 @@ function atmosphere.getTemperatureAndPressure(_ --[[point]])
 	return 293.15, 101325
 end
 _G.atmosphere = atmosphere
+
+local net = {}
+function net.dostring_in(context, code)
+	logfile:write(os.date("%F %X ")..
+		string.format("NET_DOSTRING context(%s):code(%s)\n",
+			context, code))
+end
+_G.net = net


### PR DESCRIPTION
With the ability to call the same set of functions the mission editor can call we are able to eliminate the need for campaign designers to setup end mission triggered on flags.